### PR TITLE
Use device-key REFRESH_TOKEN_AUTH for token refresh

### DIFF
--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -2,11 +2,17 @@ import asyncio
 import logging
 import time
 
+import boto3
 import requests
+from botocore.exceptions import ClientError
 from pycognito.aws_srp import AWSSRP
 
 from . import const
 from .device import KonnectDevice
+
+POOL_ID = "eu-west-1_t5HV3bFjl"
+POOL_REGION = "eu-west-1"
+CLIENT_ID = "23s0olnnniu5472ons0d9uoqt9"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +27,7 @@ class KonnectClient:
     tokenExpiresIn = None
     tokenExpiryTime = None  # New field to track token expiration time
     refreshToken = None
+    deviceKey = None
 
     def __init__(self, email, password):
         self.email = email
@@ -30,6 +37,7 @@ class KonnectClient:
         self.tokenExpiresIn = None
         self.tokenExpiryTime = None
         self.refreshToken = None  # Keeping property for compatibility with storage
+        self.deviceKey = None
 
     async def authenticate_user(self):
         """Authenticate with AWS Cognito using SRP."""
@@ -41,7 +49,7 @@ class KonnectClient:
         try:
             # Run the AWS SRP authentication in an executor
             # to avoid blocking the event loop
-            aws_response = await asyncio.get_event_loop().run_in_executor(
+            aws_response, device_key = await asyncio.get_event_loop().run_in_executor(
                 None, self.__authenticate_with_aws_srp
             )
 
@@ -52,11 +60,25 @@ class KonnectClient:
             # Calculate absolute expiry time (subtract 5 minutes for safety margin)
             self.tokenExpiryTime = time.time() + aws_result["ExpiresIn"] - 90
             self.refreshToken = aws_result["RefreshToken"]
+            self.deviceKey = device_key
 
-            _LOGGER.debug(
-                "Authentication successful, token will expire in %s seconds",
-                aws_result["ExpiresIn"],
-            )
+            if device_key:
+                _LOGGER.debug(
+                    "Authentication successful, device key captured (...%s); "
+                    "refresh will use REFRESH_TOKEN_AUTH; "
+                    "token expires in %s seconds (effective expiry %s)",
+                    device_key[-4:] if len(device_key) >= 4 else device_key,
+                    aws_result["ExpiresIn"],
+                    self._expiry_str(),
+                )
+            else:
+                _LOGGER.warning(
+                    "Authentication succeeded but NO device key was captured; "
+                    "token refresh will fall back to full SRP re-auth every cycle; "
+                    "token expires in %s seconds (effective expiry %s)",
+                    aws_result["ExpiresIn"],
+                    self._expiry_str(),
+                )
 
         except Exception as e:
             _LOGGER.error("Authentication failed: %s", str(e))
@@ -67,16 +89,76 @@ class KonnectClient:
         aws_srp = AWSSRP(
             username=self.username,
             password=self.password,
-            pool_id="eu-west-1_t5HV3bFjl",
-            pool_region="eu-west-1",
-            client_id="23s0olnnniu5472ons0d9uoqt9",
+            pool_id=POOL_ID,
+            pool_region=POOL_REGION,
+            client_id=CLIENT_ID,
         )
-        return aws_srp.authenticate_user()
+        tokens = aws_srp.authenticate_user()
+
+        device_key = None
+        ndm = tokens["AuthenticationResult"].get("NewDeviceMetadata")
+        if ndm:
+            device_key = ndm.get("DeviceKey")
+            try:
+                aws_srp.confirm_device(tokens)
+                _LOGGER.debug(
+                    "Device confirmed with Cognito (device tracking active), key ...%s",
+                    device_key[-4:] if len(device_key) >= 4 else device_key,
+                )
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("Device confirmation failed (refresh may fall back to full auth): %s", err)
+
+        return tokens, device_key
 
     async def refresh_token(self):
-        """Perform a full re-authentication instead of trying to use refresh tokens."""
-        _LOGGER.debug("Performing full re-authentication instead of token refresh")
-        await self.authenticate_user()
+        """Renew the id_token via REFRESH_TOKEN_AUTH (with DEVICE_KEY), falling
+        back to a full SRP login only if the refresh token is dead."""
+        if not self.refreshToken or not self.deviceKey:
+            _LOGGER.debug("No refresh token / device key; performing full authentication")
+            await self.authenticate_user()
+            return
+        _LOGGER.debug(
+            "Refreshing token via REFRESH_TOKEN_AUTH, device key ...%s",
+            self.deviceKey[-4:] if len(self.deviceKey) >= 4 else self.deviceKey,
+        )
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(None, self.__refresh_with_device_key)
+        except ClientError as err:
+            code = err.response.get("Error", {}).get("Code")
+            if code == "NotAuthorizedException":
+                _LOGGER.info("Refresh token expired/revoked; performing full re-authentication")
+                await self.authenticate_user()
+                return
+            raise
+        self.token = result["IdToken"]
+        self.tokenType = result["TokenType"]
+        self.tokenExpiresIn = result["ExpiresIn"]
+        self.tokenExpiryTime = time.time() + result["ExpiresIn"] - 90
+        # REFRESH_TOKEN_AUTH does not rotate the refresh token; keep the stored one
+        # unless the response unexpectedly includes a new one.
+        if "RefreshToken" in result:
+            self.refreshToken = result["RefreshToken"]
+        _LOGGER.debug(
+            "Token refreshed via REFRESH_TOKEN_AUTH, expires in %s seconds (effective expiry %s)",
+            result["ExpiresIn"],
+            self._expiry_str(),
+        )
+
+    def __refresh_with_device_key(self):
+        """Blocking REFRESH_TOKEN_AUTH including the DEVICE_KEY the token is bound to."""
+        client = boto3.client("cognito-idp", region_name=POOL_REGION)
+        response = client.initiate_auth(
+            ClientId=CLIENT_ID,
+            AuthFlow="REFRESH_TOKEN_AUTH",
+            AuthParameters={"REFRESH_TOKEN": self.refreshToken, "DEVICE_KEY": self.deviceKey},
+        )
+        return response["AuthenticationResult"]
+
+    def _expiry_str(self):
+        """Local-time string for the effective token expiry (includes the 90s safety margin)."""
+        if not self.tokenExpiryTime:
+            return "unknown"
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tokenExpiryTime))
 
     async def is_token_valid(self):
         """Check if the current token is still valid."""
@@ -165,8 +247,7 @@ class KonnectClient:
             await self.refresh_token()
         else:
             _LOGGER.debug(
-                "Token still valid, expiry in %s seconds",
-                int(self.tokenExpiryTime - time.time())
-                if self.tokenExpiryTime
-                else "unknown",
+                "Token still valid, expiry in %s seconds (effective expiry %s)",
+                int(self.tokenExpiryTime - time.time()) if self.tokenExpiryTime else "unknown",
+                self._expiry_str(),
             )

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -100,10 +100,9 @@ class KonnectClient:
         if ndm:
             device_key = ndm.get("DeviceKey")
             try:
-                aws_srp.confirm_device(tokens)
                 _LOGGER.debug(
                     "Device confirmed with Cognito (device tracking active), key ...%s",
-                    device_key[-4:] if len(device_key) >= 4 else device_key,
+                    device_key[-4:] if device_key and len(device_key) >= 4 else device_key,
                 )
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("Device confirmation failed (refresh may fall back to full auth): %s", err)

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -57,7 +57,7 @@ class KonnectClient:
             self.token = aws_result["IdToken"]
             self.tokenType = aws_result["TokenType"]
             self.tokenExpiresIn = aws_result["ExpiresIn"]
-            # Calculate absolute expiry time (subtract 5 minutes for safety margin)
+            # Calculate absolute expiry time (subtract 90 seconds for safety margin)
             self.tokenExpiryTime = time.time() + aws_result["ExpiresIn"] - 90
             self.refreshToken = aws_result["RefreshToken"]
             self.deviceKey = device_key
@@ -100,6 +100,7 @@ class KonnectClient:
         if ndm:
             device_key = ndm.get("DeviceKey")
             try:
+                aws_srp.confirm_device(tokens)
                 _LOGGER.debug(
                     "Device confirmed with Cognito (device tracking active), key ...%s",
                     device_key[-4:] if device_key and len(device_key) >= 4 else device_key,

--- a/custom_components/andersen_ev/manifest.json
+++ b/custom_components/andersen_ev/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/HA-AndersenEV/hassio-andersen-ev/issues",
   "dependencies": [],
   "codeowners": ["@lwsrbrts", "@toby200"],
-  "requirements": ["pycognito", "gql[aiohttp]"],
+  "requirements": ["pycognito", "gql[aiohttp]", "boto3"],
   "config_flow": true,
   "iot_class": "cloud_polling",
   "version": "0.7.1",

--- a/custom_components/andersen_ev/tests/test_client.py
+++ b/custom_components/andersen_ev/tests/test_client.py
@@ -1,0 +1,259 @@
+"""Tests for KonnectClient Cognito auth and device-key-aware token refresh."""
+# pylint: disable=protected-access
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from andersen_ev.konnect.client import KonnectClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_srp_auth_response(device_key=None):
+    """Return a minimal AWS SRP authentication response dict."""
+    result = {
+        "AuthenticationResult": {
+            "IdToken": "test-id-token",
+            "TokenType": "Bearer",
+            "ExpiresIn": 3600,
+            "RefreshToken": "test-refresh-token",
+        }
+    }
+    if device_key is not None:
+        result["AuthenticationResult"]["NewDeviceMetadata"] = {"DeviceKey": device_key}
+    return result
+
+
+def _make_cognito_refresh_response():
+    """Return a minimal Cognito REFRESH_TOKEN_AUTH AuthenticationResult (no RefreshToken)."""
+    return {
+        "AuthenticationResult": {
+            "IdToken": "refreshed-id-token",
+            "TokenType": "Bearer",
+            "ExpiresIn": 3600,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# authenticate_user() — device key capture & device confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticate:
+    """Tests for authenticate_user() device key capture and device confirmation."""
+
+    @pytest.mark.asyncio
+    async def test_authenticate_captures_device_key_and_confirms_device(self):
+        """authenticate_user() stores deviceKey and calls confirm_device on NewDeviceMetadata."""
+        client = KonnectClient("user@example.com", "password")
+        auth_response = _make_srp_auth_response(device_key="dk-1")
+
+        mock_aws_srp = MagicMock()
+        mock_aws_srp.authenticate_user.return_value = auth_response
+
+        with patch("andersen_ev.konnect.client.AWSSRP", return_value=mock_aws_srp):
+            with patch.object(
+                client,
+                "_KonnectClient__fetchUsername",
+                new=AsyncMock(return_value="test-username"),
+            ):
+                await client.authenticate_user()
+
+        assert client.deviceKey == "dk-1"
+        assert client.token == "test-id-token"
+        assert client.refreshToken == "test-refresh-token"
+        mock_aws_srp.confirm_device.assert_called_once_with(auth_response)
+
+    @pytest.mark.asyncio
+    async def test_authenticate_no_device_metadata_leaves_device_key_none(self):
+        """authenticate_user() leaves deviceKey as None when no NewDeviceMetadata present."""
+        client = KonnectClient("user@example.com", "password")
+        auth_response = _make_srp_auth_response()  # no NewDeviceMetadata
+
+        mock_aws_srp = MagicMock()
+        mock_aws_srp.authenticate_user.return_value = auth_response
+
+        with patch("andersen_ev.konnect.client.AWSSRP", return_value=mock_aws_srp):
+            with patch.object(
+                client,
+                "_KonnectClient__fetchUsername",
+                new=AsyncMock(return_value="test-username"),
+            ):
+                await client.authenticate_user()
+
+        assert client.deviceKey is None
+        assert client.token == "test-id-token"
+        mock_aws_srp.confirm_device.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_authenticate_continues_when_confirm_device_fails(self):
+        """authenticate_user() succeeds and logs a warning if confirm_device raises."""
+        client = KonnectClient("user@example.com", "password")
+        auth_response = _make_srp_auth_response(device_key="dk-warn")
+
+        mock_aws_srp = MagicMock()
+        mock_aws_srp.authenticate_user.return_value = auth_response
+        mock_aws_srp.confirm_device.side_effect = Exception("confirm failed")
+
+        with patch("andersen_ev.konnect.client.AWSSRP", return_value=mock_aws_srp):
+            with patch.object(
+                client,
+                "_KonnectClient__fetchUsername",
+                new=AsyncMock(return_value="test-username"),
+            ):
+                # Should NOT raise despite confirm_device failure
+                await client.authenticate_user()
+
+        # The token should still be set; deviceKey captured from NewDeviceMetadata
+        assert client.token == "test-id-token"
+        assert client.deviceKey == "dk-warn"
+
+
+# ---------------------------------------------------------------------------
+# refresh_token() — device-key-aware path and fallbacks
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshToken:
+    """Tests for refresh_token() device-key-aware refresh and fallback behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_device_key(self):
+        """refresh_token() calls REFRESH_TOKEN_AUTH with DEVICE_KEY and updates token fields."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "rt"
+        client.deviceKey = "dk"
+
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = _make_cognito_refresh_response()
+
+        with patch("andersen_ev.konnect.client.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_cognito
+            await client.refresh_token()
+
+        # Verify the Cognito client was created for the correct region
+        mock_boto3.client.assert_called_once_with("cognito-idp", region_name="eu-west-1")
+
+        # Verify initiate_auth was called with the expected parameters
+        mock_cognito.initiate_auth.assert_called_once_with(
+            ClientId="23s0olnnniu5472ons0d9uoqt9",
+            AuthFlow="REFRESH_TOKEN_AUTH",
+            AuthParameters={"REFRESH_TOKEN": "rt", "DEVICE_KEY": "dk"},
+        )
+
+        # Verify token fields were updated
+        assert client.token == "refreshed-id-token"
+        assert client.tokenType == "Bearer"
+        assert client.tokenExpiresIn == 3600
+
+    @pytest.mark.asyncio
+    async def test_dead_refresh_token_falls_back_to_full_auth(self):
+        """refresh_token() falls back to authenticate_user() on NotAuthorizedException."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "expired-rt"
+        client.deviceKey = "dk"
+
+        not_authorized = ClientError(
+            {"Error": {"Code": "NotAuthorizedException", "Message": "Invalid Refresh Token"}},
+            "InitiateAuth",
+        )
+
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = not_authorized
+
+        with patch("andersen_ev.konnect.client.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_cognito
+            with patch.object(client, "authenticate_user", new_callable=AsyncMock) as mock_full_auth:
+                await client.refresh_token()
+
+        mock_full_auth.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_token_or_device_key_falls_back_to_full_auth(self):
+        """refresh_token() falls back immediately when refreshToken or deviceKey is absent."""
+        client = KonnectClient("user@example.com", "password")
+        # Both are None by default — guard should trigger before any Cognito call
+
+        with patch.object(client, "authenticate_user", new_callable=AsyncMock) as mock_full_auth:
+            await client.refresh_token()
+
+        mock_full_auth.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_only_device_key_missing_falls_back_to_full_auth(self):
+        """refresh_token() falls back when refreshToken is set but deviceKey is None."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "rt"
+        # deviceKey remains None
+
+        with patch.object(client, "authenticate_user", new_callable=AsyncMock) as mock_full_auth:
+            await client.refresh_token()
+
+        mock_full_auth.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_not_rotated_when_absent_from_response(self):
+        """refresh_token() keeps the existing refreshToken when Cognito does not return a new one."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "original-rt"
+        client.deviceKey = "dk"
+
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = _make_cognito_refresh_response()
+
+        with patch("andersen_ev.konnect.client.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_cognito
+            await client.refresh_token()
+
+        # The stored refresh token must NOT have been overwritten
+        assert client.refreshToken == "original-rt"
+
+    @pytest.mark.asyncio
+    async def test_refresh_updates_refresh_token_if_rotated(self):
+        """refresh_token() replaces refreshToken when Cognito unexpectedly rotates it."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "old-rt"
+        client.deviceKey = "dk"
+
+        rotated_response = {
+            "AuthenticationResult": {
+                "IdToken": "new-id-token",
+                "TokenType": "Bearer",
+                "ExpiresIn": 3600,
+                "RefreshToken": "rotated-rt",
+            }
+        }
+
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.return_value = rotated_response
+
+        with patch("andersen_ev.konnect.client.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_cognito
+            await client.refresh_token()
+
+        assert client.refreshToken == "rotated-rt"
+
+    @pytest.mark.asyncio
+    async def test_non_auth_client_error_is_reraised(self):
+        """refresh_token() re-raises ClientError codes other than NotAuthorizedException."""
+        client = KonnectClient("user@example.com", "password")
+        client.refreshToken = "rt"
+        client.deviceKey = "dk"
+
+        service_error = ClientError(
+            {"Error": {"Code": "TooManyRequestsException", "Message": "slow down"}},
+            "InitiateAuth",
+        )
+
+        mock_cognito = MagicMock()
+        mock_cognito.initiate_auth.side_effect = service_error
+
+        with patch("andersen_ev.konnect.client.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_cognito
+            with pytest.raises(ClientError):
+                await client.refresh_token()


### PR DESCRIPTION
## Summary

`refresh_token()` currently performs a full SRP username/password re-authentication
on each token expiry. This PR switches it to Cognito's `REFRESH_TOKEN_AUTH` flow, so a
full password login only happens about once per refresh-token lifetime (around 30 days)
instead of on every token expiry.

## Why this is needed

It's more than just cutting down the number of logins. Replaying the user's username and
password against Cognito roughly 24 times a day, indefinitely, isn't the right auth
pattern and carries some real downsides:

- **Automated abuse detection.** A steady stream of full password logins from one
  account can look like repeated automated login attempts. Cognito may respond with
  extra verification challenges, throttling, or temporary blocks, any of which would take
  the integration (and the user's charger control) offline with a failure that's hard to
  diagnose.
- **Unnecessary password use.** `REFRESH_TOKEN_AUTH` is the mechanism Cognito provides so
  that long-lived sessions don't have to keep resubmitting the password. Every extra
  password round-trip is something we can avoid.
- **Account friction.** Frequent password logins are the kind of activity that can trip
  rate limits or force-logout logic on the account.

The refresh-token flow is the intended, supported way to keep a session alive. The only
reason this repo doesn't already use it is the device-tracking detail described below.

## Background / root cause

The changelog (v0.3.0) notes *"refresh tokens just don't work 🤷"*, and the code falls
back to a full re-auth for that reason. Refresh tokens *do* work on this pool. The catch
is that the Andersen Cognito pool (`eu-west-1_t5HV3bFjl`) has **device tracking enabled**.
With device tracking, `REFRESH_TOKEN_AUTH` only succeeds if you:

1. call `confirm_device(...)` once at SRP login, **and**
2. include the captured `DEVICE_KEY` on every refresh request.

Without the device key, Cognito returns `NotAuthorizedException: Invalid Refresh Token`,
which is exactly the symptom that made refresh tokens look broken.

This device-tracking behaviour was worked out against [strobejb/andersen-ev](https://github.com/strobejb/andersen-ev)
(the same project this repo's GraphQL schema is borrowed from) plus direct
experimentation against the live pool. `confirm_device` and the device-aware SRP flow
are provided by `pycognito`, already a dependency here.

## Changes

- Capture `AuthenticationResult.NewDeviceMetadata.DeviceKey` during SRP login and
  call `confirm_device()` (logs a warning and continues if confirmation fails).
- Store the device key on the client (`deviceKey`).
- Rewrite `refresh_token()` to renew the id_token via `REFRESH_TOKEN_AUTH` with the
  device key, updating token/expiry fields. The stored refresh token is preserved
  unless Cognito rotates it.
- Blocking boto3/pycognito calls run in an executor to avoid blocking the event loop.
- Declare `boto3` in `manifest.json` requirements: the refresh path adds a direct top-level
  `import boto3` (previously only a transitive dependency via `pycognito`), so it is now
  declared explicitly per HA convention.

## Safety / graceful degradation

The previous behaviour is the fallback, so the worst case is unchanged from today:

- No refresh token or no device key: full `authenticate_user()`.
- Refresh token rejected (`NotAuthorizedException`): full `authenticate_user()`.
- Any other `ClientError`: re-raised.

A restart re-runs SRP login (config entries store only email + password), which
re-confirms the device and captures a fresh key, so the device key does not need
to be persisted.

## Testing

- New `tests/test_client.py` covers device-key capture, device confirmation
  (including the warn-and-continue path), the device-key refresh, refresh-token
  rotation handling, and every fallback branch.
- Verified live against the production Konnect+ API: after the initial SRP login,
  each token renewal succeeds via `REFRESH_TOKEN_AUTH` with no further password
  logins.

## Notes

`POOL_ID` / `POOL_REGION` / `CLIENT_ID` are the existing public Konnect+ app values,
promoted to module constants so the refresh path can reuse them (no behavioural
change, since the same values were already hard-coded in the SRP call). I've pulled the
latest Andersen app APK and confirmed these same Cognito pool and client values are
still present in the current release.
