### PR TITLE
ci: fix Python 3.14 install by building litellm against the stable ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # litellm ships a Rust/PyO3 native build (pulled transitively via
+    # homeassistant -> hass-nabucasa) whose PyO3 has no Python 3.14 support yet,
+    # so the 3.14 install fails at the native build. Build against the stable ABI
+    # instead. Remove once litellm publishes 3.14-compatible wheels.
+    env:
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
     strategy:
       matrix:
         python-version: ["3.13", "3.14"]


### PR DESCRIPTION
## Problem

The `Test (Python 3.14)` matrix leg started failing at the dependency install step (before any test runs), which fails the `CI Success` gate and blocks every PR. It is upstream dependency drift, not a code change: `uv` now resolves `litellm 1.92.0` (pulled transitively by `homeassistant` -> `hass-nabucasa` -> `litellm`), whose Rust/PyO3 native build rejects Python 3.14:

```
error: the configured Python interpreter version (3.14) is newer than
       PyO3's maximum supported version (3.13)
  = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this
    check and build anyway using the stable ABI
```

Python 3.13 is unaffected (PyO3 supports it), so only the 3.14 leg breaks.

## Fix

Set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` on the `test` job, exactly as the PyO3 error recommends, so the native extension builds against the stable ABI on 3.14. This keeps 3.14 a real, blocking matrix leg rather than weakening the gate. Harmless on the 3.13 leg (that build already succeeds). A code comment notes it can be removed once litellm publishes 3.14-compatible wheels.

## Verification

This PR's own CI run exercises the patched workflow, so a green `Test (Python 3.14)` here confirms the fix.
