### PR TITLE
chore: mark verified Bronze quality scale rules as done

### DIFF
--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -1,24 +1,24 @@
 rules:
   # Bronze
-  action-setup: todo
-  appropriate-polling: todo
-  brands: todo
-  common-modules: todo
-  config-flow: todo
-  config-flow-test-coverage: todo
-  dependency-transparency: todo
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
   docs-actions: todo
   docs-conditions: todo
   docs-high-level-description: todo
   docs-installation-instructions: todo
   docs-removal-instructions: todo
   docs-triggers: todo
-  entity-event-setup: todo
+  entity-event-setup: done
   entity-unique-id: done
   has-entity-name: todo
   runtime-data: todo
-  test-before-configure: todo
-  test-before-setup: todo
+  test-before-configure: done
+  test-before-setup: done
   unique-config-entry: done
 
   # Silver


### PR DESCRIPTION
## Summary

- Audit Bronze quality scale rules and mark 10 items as `done` that are already satisfied by the existing codebase
- Verified: action-setup, appropriate-polling, brands, common-modules, config-flow, config-flow-test-coverage, dependency-transparency, entity-event-setup, test-before-configure, test-before-setup

## Evidence

| Rule | Evidence |
|------|----------|
| action-setup | Services registered in `__init__.py:async_setup_entry` |
| appropriate-polling | `DataUpdateCoordinator` with 60s interval |
| brands | `brand/` directory with icon + logo (light/dark, 1x/2x) |
| common-modules | Uses `DataUpdateCoordinator` + `CoordinatorEntity` |
| config-flow | `config_flow: true` in manifest, `config_flow.py` exists |
| config-flow-test-coverage | `tests/test_config_flow.py` added in #52 |
| dependency-transparency | All runtime deps in manifest `requirements` |
| entity-event-setup | All platforms create entities in `async_setup_entry` via `CoordinatorEntity` |
| test-before-configure | `validate_input()` authenticates before `async_create_entry` |
| test-before-setup | `async_config_entry_first_refresh()` raises on failure |

## Remaining Bronze work

- `has-entity-name` - code change needed
- `runtime-data` - code change needed
- `docs-*` (6 rules) - external documentation
