### PR TITLE
refactor: add has_entity_name to all entity classes

### DIFF
--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -32,12 +32,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class AndersenEvLock(CoordinatorEntity, LockEntity):  # pylint: disable=abstract-method
     """Representation of an Andersen EV charging lock."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: AndersenEvCoordinator, device) -> None:
         """Initialize the lock."""
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.device_id}_lock"
-        self._attr_name = f"{device.friendly_name} Lock"
+        self._attr_name = "Lock"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
             name=f"{device.friendly_name} ({device.device_id})",

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -15,7 +15,7 @@ rules:
   docs-triggers: todo
   entity-event-setup: done
   entity-unique-id: done
-  has-entity-name: todo
+  has-entity-name: done
   runtime-data: todo
   test-before-configure: done
   test-before-setup: done

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -308,13 +308,15 @@ async def async_setup_entry(
 class AndersenEvBaseSensor(CoordinatorEntity, SensorEntity):
     """Base class for Andersen EV sensors."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: AndersenEvCoordinator, device, sensor_type, name_suffix, data_key=None) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = f"{device.friendly_name} {name_suffix}"
+        self._attr_name = name_suffix
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},
@@ -430,11 +432,13 @@ class AndersenEvConnectorSensor(CoordinatorEntity, SensorEntity):
         "unknown",
     ]
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: AndersenEvCoordinator, device, icon=None) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
-        self._attr_name = f"{device.friendly_name} Connector"
+        self._attr_name = "Connector"
         self._attr_unique_id = f"{device.device_id}_connector"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},
@@ -546,6 +550,8 @@ class AndersenEvConnectorSensor(CoordinatorEntity, SensorEntity):
 class AndersenEvChargeStatusSensor(CoordinatorEntity, SensorEntity):
     """Sensor for Andersen EV charge status values."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: AndersenEvCoordinator,
@@ -563,7 +569,7 @@ class AndersenEvChargeStatusSensor(CoordinatorEntity, SensorEntity):
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = f"{device.friendly_name} {name_suffix}"
+        self._attr_name = name_suffix
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},
@@ -652,6 +658,8 @@ class AndersenEvChargeStatusSensor(CoordinatorEntity, SensorEntity):
 class AndersenEvLiveSensor(CoordinatorEntity, SensorEntity):
     """Sensor for Andersen EV live status values."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: AndersenEvCoordinator,
@@ -669,7 +677,7 @@ class AndersenEvLiveSensor(CoordinatorEntity, SensorEntity):
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = f"{device.friendly_name} {name_suffix}"
+        self._attr_name = name_suffix
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -60,6 +60,8 @@ async def async_setup_entry(
 class AndersenEvScheduleSwitch(CoordinatorEntity, SwitchEntity):  # pylint: disable=abstract-method
     """Representation of an Andersen EV charging schedule switch."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: AndersenEvCoordinator,
@@ -72,8 +74,7 @@ class AndersenEvScheduleSwitch(CoordinatorEntity, SwitchEntity):  # pylint: disa
         self._device = device
         self._schedule_index = index
         self._schedule_name = schedule_name
-        # Use standardized naming format: "Friendly Name Schedule X"
-        self._attr_name = f"{device.friendly_name} Schedule {index + 1}"
+        self._attr_name = f"Schedule {index + 1}"
         self._attr_unique_id = f"{device.device_id}_schedule_{index}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},


### PR DESCRIPTION
## Summary
- Add `_attr_has_entity_name = True` to all entity classes (lock, sensors, switches)
- Change entity names from full device-prefixed names to suffixes (HA auto-prepends device name)
- Mark `has-entity-name` quality scale rule as done

## Test plan
- [ ] CI passes (lint, tests, hassfest)
- [ ] Entity names render correctly (device name + suffix)
