### PR TITLE
refactor: migrate to entry.runtime_data and complete Bronze docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ data:
   device_id: "YOUR_DEVICE_ID"
 ```
 
+## Removal
+
+1. In Home Assistant, go to **Settings > Devices & Services**.
+2. Click the Andersen EV integration entry, then click **Delete**.
+3. Restart Home Assistant.
+4. (Optional) Uninstall via HACS: navigate to HACS > Integrations, find Andersen EV, and remove it.
+
 ## Contributing
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the branch model, commit
 conventions, and release process before opening a pull request.

--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -24,16 +23,12 @@ from .konnect.client import KonnectClient
 
 PLATFORMS = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
 
+type AndersenEvConfigEntry = ConfigEntry[AndersenEvCoordinator]
+
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
-    """Set up the Andersen EV component."""
-    hass.data[DOMAIN] = {}
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -> bool:
     """Set up Andersen EV from a config entry."""
     email = entry.data["email"]
     password = entry.data["password"]
@@ -45,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     # Register services
     async def disable_all_schedules(call: ServiceCall) -> None:
@@ -129,19 +124,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -> bool:
     """Unload a config entry."""
-    coordinator: AndersenEvCoordinator | None = hass.data[DOMAIN].get(entry.entry_id)
-
-    if coordinator:
-        await asyncio.gather(*(device.close() for device in coordinator.devices), return_exceptions=True)
-
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    await asyncio.gather(*(device.close() for device in entry.runtime_data.devices), return_exceptions=True)
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 class AndersenEvCoordinator(DataUpdateCoordinator):

--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -6,21 +6,22 @@ import logging
 from typing import Any
 
 from homeassistant.components.lock import LockEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AndersenEvCoordinator
+from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: AndersenEvConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up the Andersen EV lock platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
     for device in coordinator.data:

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -7,16 +7,20 @@ rules:
   config-flow: done
   config-flow-test-coverage: done
   dependency-transparency: done
-  docs-actions: todo
-  docs-conditions: todo
-  docs-high-level-description: todo
-  docs-installation-instructions: todo
-  docs-removal-instructions: todo
-  docs-triggers: todo
+  docs-actions: done
+  docs-conditions:
+    status: exempt
+    comment: Integration does not provide custom conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: Integration does not provide custom triggers.
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
-  runtime-data: todo
+  runtime-data: done
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -22,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AndersenEvCoordinator
+from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,11 +29,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: AndersenEvConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Andersen EV sensor platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
     for device in coordinator.data:

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -7,12 +7,11 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AndersenEvCoordinator
+from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 from .konnect import const
 
@@ -21,11 +20,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: AndersenEvConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Andersen EV schedule switches."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
     for device in coordinator.data:


### PR DESCRIPTION
## Summary
- Migrate coordinator storage from `hass.data[DOMAIN]` to `entry.runtime_data` with a typed `AndersenEvConfigEntry` alias
- Remove `async_setup` (no longer needed without `hass.data` init)
- Simplify `async_unload_entry` (direct access via `entry.runtime_data`, no dict cleanup)
- Update all entity platforms (lock, sensor, switch) to use `entry.runtime_data`
- Mark `runtime-data` quality scale rule as done
- Mark 4 Bronze docs rules as done (actions, high-level-description, installation, removal) and 2 as exempt (conditions, triggers)
- Add Removal section to README

## Test plan
- [ ] CI passes (lint, test matrix, hassfest, HACS)
- [ ] Install beta via HACS, confirm no errors on load
- [ ] Verify entities load with correct values (lock, sensors, switches)
- [ ] Toggle lock or switch to confirm entity platforms still work
