### PR TITLE
ci: promote hassfest + HACS to blocking and declare Bronze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest
-    # continue-on-error until requirements in manifest.json are pinned (B5)
-    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master @ f4ca6f6 (2026-06-22)
@@ -96,15 +94,14 @@ jobs:
     name: CI Success
     # Stable required-status-check target: its name never changes when the
     # test matrix changes, so branch protection can require this one context.
-    # Tighten later (e.g. add hassfest at B5) by extending `needs` + the check.
     if: ${{ always() }}
-    needs: [lint, test]
+    needs: [lint, test, hassfest, hacs]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs succeeded
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
-            echo "A required job did not succeed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }})"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.hassfest.result }}" != "success" ] || [ "${{ needs.hacs.result }}" != "success" ]; then
+            echo "A required job did not succeed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, hassfest=${{ needs.hassfest.result }}, hacs=${{ needs.hacs.result }})"
             exit 1
           fi
           echo "All required jobs succeeded"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## Status
 ![CI](https://github.com/HA-AndersenEV/hassio-andersen-ev/actions/workflows/ci.yml/badge.svg?branch=main)
+![HA Quality Scale: Bronze](https://img.shields.io/badge/HA_Quality_Scale-Bronze-cd7f32)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/HA-AndersenEV/hassio-andersen-ev)](https://github.com/HA-AndersenEV/hassio-andersen-ev/releases)
 [![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.andersen_ev.total)

--- a/custom_components/andersen_ev/manifest.json
+++ b/custom_components/andersen_ev/manifest.json
@@ -12,6 +12,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/HA-AndersenEV/hassio-andersen-ev/issues",
+  "quality_scale": "bronze",
   "requirements": [
     "pycognito",
     "gql[aiohttp]",


### PR DESCRIPTION
## Summary
- Remove continue-on-error from hassfest job, making it a blocking CI check
- Add hassfest and HACS to the CI Success gate job
- Add quality_scale: bronze to manifest.json
- Add Quality Scale badge to README

## Test plan
- [ ] CI passes with hassfest now blocking (already confirmed green on latest main)
- [ ] HACS validation continues to pass
- [ ] CI Success gate now requires all four jobs (lint, test, hassfest, hacs)
