### PR TITLE
feat: clearer error reporting during sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/HA-AndersenEV/hassio-andersen-ev)](https://github.com/HA-AndersenEV/hassio-andersen-ev/releases)
 [![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.andersen_ev.total)
 
-### 0.8.0
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Features
 * Switch entities for each charging schedule allows enabling/disabling charge schedules.

--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     SERVICE_RCM_RESET,
 )
 from .konnect.client import KonnectClient
+from .konnect.exceptions import AndersenError
 
 PLATFORMS = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
 
@@ -152,7 +153,7 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
         """Fetch data from API endpoint."""
         try:
             devices = await self.client.getDevices()
-        except Exception as err:
+        except AndersenError as err:
             if self.devices:
                 _LOGGER.warning("API error, using cached device data: %s", err)
                 return self.devices

--- a/custom_components/andersen_ev/config_flow.py
+++ b/custom_components/andersen_ev/config_flow.py
@@ -46,6 +46,9 @@ async def validate_input(_hass: HomeAssistant, data):
     except (AndersenConnectionError, AndersenError) as e:
         _LOGGER.error("Connection error: %s", e)
         raise CannotConnect from e
+    except Exception as e:
+        _LOGGER.error("Unexpected error during validation: %s", e)
+        raise CannotConnect from e
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=abstract-method

--- a/custom_components/andersen_ev/config_flow.py
+++ b/custom_components/andersen_ev/config_flow.py
@@ -12,6 +12,7 @@ from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN
 
 # Import the konnect module from the local directory
 from .konnect.client import KonnectClient
+from .konnect.exceptions import AndersenAuthError, AndersenConnectionError, AndersenError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,10 +40,11 @@ async def validate_input(_hass: HomeAssistant, data):
 
         # Return info to be stored in the config entry
         return {"title": f"Andersen EV ({data[CONF_EMAIL]})"}
-    except Exception as e:
-        _LOGGER.error("Authentication error: %s", str(e))
-        if "Incorrect email address" in str(e) or "Failed to sign in" in str(e):
-            raise InvalidAuth from e
+    except AndersenAuthError as e:
+        _LOGGER.error("Authentication error: %s", e)
+        raise InvalidAuth from e
+    except (AndersenConnectionError, AndersenError) as e:
+        _LOGGER.error("Connection error: %s", e)
         raise CannotConnect from e
 
 

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -9,6 +9,7 @@ from pycognito.aws_srp import AWSSRP
 
 from . import const
 from .device import KonnectDevice
+from .exceptions import AndersenAuthError, AndersenConnectionError
 
 POOL_ID = "eu-west-1_t5HV3bFjl"
 POOL_REGION = "eu-west-1"
@@ -82,7 +83,7 @@ class KonnectClient:
 
         except Exception as e:
             _LOGGER.error("Authentication failed: %s", str(e))
-            raise RuntimeError(f"Failed to sign in: {e!s}") from e
+            raise AndersenAuthError(f"Failed to sign in: {e!s}") from e
 
     def __authenticate_with_aws_srp(self):
         # This is executed in the executor pool
@@ -195,7 +196,7 @@ class KonnectClient:
                 response.status_code,
                 response.text,
             )
-            return devices
+            raise AndersenConnectionError(f"API returned status {response.status_code}")
 
         response_body = response.json()
 
@@ -230,13 +231,13 @@ class KonnectClient:
         )
 
         if response.status_code != 200:
-            raise RuntimeError("Incorrect email address")
+            raise AndersenAuthError("Incorrect email address")
 
         # {'error': 'Pending user with email "x" not found'}
         # {'username': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:x'}
         response_body = response.json()
         if "username" not in response_body:
-            raise RuntimeError("Incorrect email address")
+            raise AndersenAuthError("Incorrect email address")
 
         return response_body["username"]
 

--- a/custom_components/andersen_ev/konnect/exceptions.py
+++ b/custom_components/andersen_ev/konnect/exceptions.py
@@ -1,0 +1,17 @@
+"""Typed exceptions for the Andersen EV konnect layer."""
+
+
+class AndersenError(Exception):
+    """Base exception for Andersen EV integration errors."""
+
+
+class AndersenAuthError(AndersenError):
+    """Raised when authentication fails (bad credentials, unknown email)."""
+
+
+class AndersenConnectionError(AndersenError):
+    """Raised when the API is unreachable or returns an unexpected HTTP status."""
+
+
+class AndersenApiError(AndersenError):
+    """Raised when the API response shape is unexpected."""

--- a/custom_components/andersen_ev/tests/test_config_flow.py
+++ b/custom_components/andersen_ev/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from andersen_ev.config_flow import CannotConnect, ConfigFlow, InvalidAuth, validate_input
 from andersen_ev.const import CONF_EMAIL, CONF_PASSWORD
+from andersen_ev.konnect.exceptions import AndersenAuthError, AndersenConnectionError
 
 MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
 
@@ -62,15 +63,22 @@ class TestValidateInput:
 
     @pytest.mark.asyncio
     async def test_sign_in_failure_raises_invalid_auth(self):
-        """A 'Failed to sign in' auth error is mapped to InvalidAuth."""
-        with _patch_konnect_client(auth_error=Exception("Failed to sign in")):
+        """An AndersenAuthError from authenticate_user is mapped to InvalidAuth."""
+        with _patch_konnect_client(auth_error=AndersenAuthError("Failed to sign in")):
             with pytest.raises(InvalidAuth):
                 await validate_input(None, {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"})
 
     @pytest.mark.asyncio
+    async def test_connection_failure_raises_cannot_connect(self):
+        """An AndersenConnectionError is mapped to CannotConnect."""
+        with _patch_konnect_client(auth_error=AndersenConnectionError("network unreachable")):
+            with pytest.raises(CannotConnect):
+                await validate_input(None, {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "testpass"})
+
+    @pytest.mark.asyncio
     async def test_unexpected_failure_raises_cannot_connect(self):
-        """An unrecognized error is mapped to CannotConnect."""
-        with _patch_konnect_client(auth_error=Exception("network unreachable")):
+        """An unrecognized (non-Andersen) error is still mapped to CannotConnect."""
+        with _patch_konnect_client(auth_error=Exception("something unexpected")):
             with pytest.raises(CannotConnect):
                 await validate_input(None, {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "testpass"})
 
@@ -120,7 +128,7 @@ class TestAsyncStepUser:
         flow = _make_flow()
         user_input = {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"}
 
-        with _patch_konnect_client(auth_error=Exception("Failed to sign in")):
+        with _patch_konnect_client(auth_error=AndersenAuthError("Failed to sign in")):
             result = await flow.async_step_user(user_input)
 
         assert result["type"] is FlowResultType.FORM
@@ -130,11 +138,11 @@ class TestAsyncStepUser:
 
     @pytest.mark.asyncio
     async def test_cannot_connect_shows_form_error_without_setting_unique_id(self):
-        """A generic failure re-shows the form and never touches the unique id."""
+        """A connection failure re-shows the form and never touches the unique id."""
         flow = _make_flow()
         user_input = {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "testpass"}
 
-        with _patch_konnect_client(auth_error=Exception("boom")):
+        with _patch_konnect_client(auth_error=AndersenConnectionError("boom")):
             result = await flow.async_step_user(user_input)
 
         assert result["type"] is FlowResultType.FORM


### PR DESCRIPTION
## Summary
- New `konnect/exceptions.py` with `AndersenAuthError`, `AndersenConnectionError`, `AndersenApiError` hierarchy
- Config flow catches typed exceptions instead of string-matching error messages (IMPR #9)
- Coordinator catches `AndersenError` instead of bare `Exception`
- README version heading replaced with link to auto-maintained CHANGELOG.md

## Test plan
- [ ] CI passes (lint + tests + hassfest + HACS)
- [ ] Config flow still shows correct error for bad email vs bad password vs unreachable API
