### PR TITLE
feat: prompt to re-enter password when credentials expire

### DIFF
--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -20,7 +21,7 @@ from .const import (
     SERVICE_RCM_RESET,
 )
 from .konnect.client import KonnectClient
-from .konnect.exceptions import AndersenError
+from .konnect.exceptions import AndersenAuthError, AndersenError
 
 PLATFORMS = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
 
@@ -153,6 +154,8 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
         """Fetch data from API endpoint."""
         try:
             devices = await self.client.getDevices()
+        except AndersenAuthError as err:
+            raise ConfigEntryAuthFailed("Authentication failed - please re-enter credentials") from err
         except AndersenError as err:
             if self.devices:
                 _LOGGER.warning("API error, using cached device data: %s", err)

--- a/custom_components/andersen_ev/config_flow.py
+++ b/custom_components/andersen_ev/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow for Andersen EV integration."""
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -75,6 +77,43 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=a
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle reauth when credentials become invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+        """Handle reauth confirmation step - user re-enters password."""
+        errors = {}
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            try:
+                await validate_input(
+                    self.hass,
+                    {
+                        CONF_EMAIL: reauth_entry.data[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during reauth")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_PASSWORD: user_input[CONF_PASSWORD]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={"email": reauth_entry.data[CONF_EMAIL]},
+            errors=errors,
+        )
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -34,7 +34,7 @@ rules:
   integration-owner: todo
   log-when-unavailable: todo
   parallel-updates: todo
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/custom_components/andersen_ev/strings.json
+++ b/custom_components/andersen_ev/strings.json
@@ -8,6 +8,13 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Andersen EV",
+        "description": "The credentials for {email} are no longer valid. Please re-enter your password.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -16,7 +23,8 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Re-authentication successful"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add reauth flow (async_step_reauth + async_step_reauth_confirm) so users are prompted to re-enter their password when credentials expire
- Coordinator raises ConfigEntryAuthFailed on auth errors to trigger the reauth UI
- Add reauth strings to strings.json
- Mark reauthentication-flow as done in quality_scale.yaml

## Test plan
- [ ] CI passes (lint + tests + hassfest)
- [ ] Config flow test coverage maintained
