### PR TITLE
feat: raise errors to the user when service actions fail

### DIFF
--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -55,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 await device.disable_all_schedules()
                 await coordinator.async_request_refresh()
                 break
+        else:
+            raise HomeAssistantError(f"Device {device_id} not found")
 
     async def get_device_info(call: ServiceCall) -> dict:
         """Get detailed information for a device and return it to the UI."""
@@ -67,9 +69,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 if device_info:
                     # Return the device info as a response that will be shown in the UI
                     return device_info
-                return {"error": "Failed to retrieve device information"}
+                raise HomeAssistantError("Failed to retrieve device information")
 
-        return {"error": f"Device with ID {device_id} not found"}
+        raise HomeAssistantError(f"Device {device_id} not found")
 
     async def get_device_status(call: ServiceCall) -> dict:
         """Get detailed status for a device and return it to the UI."""
@@ -81,9 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 device_status = await device.get_detailed_device_status()
                 if device_status:
                     return device_status
-                return {"error": "Failed to retrieve device status"}
+                raise HomeAssistantError("Failed to retrieve device status")
 
-        return {"error": f"Device with ID {device_id} not found"}
+        raise HomeAssistantError(f"Device {device_id} not found")
 
     async def reset_rcm(call: ServiceCall) -> None:
         """Reset RCM fault for a device."""
@@ -95,6 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 await device.reset_rcm()
                 await coordinator.async_request_refresh()
                 break
+        else:
+            raise HomeAssistantError(f"Device {device_id} not found")
 
     # Register services using simpler schema
     service_schema = vol.Schema({vol.Required(ATTR_DEVICE_ID): str})

--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -109,12 +110,14 @@ class AndersenEvLock(CoordinatorEntity, LockEntity):  # pylint: disable=abstract
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the charging station (disable charging)."""
-        await self._device.disable()
+        if not await self._device.disable():
+            raise HomeAssistantError("Failed to lock the charger")
         _LOGGER.debug("Locking device %s (disabling charging)", self._device.friendly_name)
         await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the charging station (enable charging)."""
-        await self._device.enable()
+        if not await self._device.enable():
+            raise HomeAssistantError("Failed to unlock the charger")
         _LOGGER.debug("Unlocking device %s (enabling charging)", self._device.friendly_name)
         await self.coordinator.async_request_refresh()

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -26,7 +26,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: todo
   docs-configuration-parameters: todo
   docs-installation-parameters: todo

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -160,11 +161,7 @@ class AndersenEvScheduleSwitch(CoordinatorEntity, SwitchEntity):  # pylint: disa
                     or "deviceStatus" not in device_info
                     or "scheduleSlotsArray" not in device_info["deviceStatus"]
                 ):
-                    _LOGGER.warning(
-                        "Failed to get schedule slots for %s",
-                        self._device.friendly_name,
-                    )
-                    return
+                    raise HomeAssistantError("Failed to retrieve schedule data")
                 schedule_slots = copy.deepcopy(device_info["deviceStatus"]["scheduleSlotsArray"])
             else:
                 # Use the data from the coordinator
@@ -201,16 +198,12 @@ class AndersenEvScheduleSwitch(CoordinatorEntity, SwitchEntity):  # pylint: disa
                     # Request a refresh of the coordinator data to update all entities
                     await self.coordinator.async_request_refresh()
                 else:
-                    _LOGGER.warning(
-                        "Failed to update schedule state for %s Schedule %s",
-                        self._device.friendly_name,
-                        self._schedule_index + 1,
-                    )
+                    raise HomeAssistantError(f"Failed to update schedule for {self._device.friendly_name}")
             else:
-                _LOGGER.warning("Schedule index %s out of range", self._schedule_index)
+                raise HomeAssistantError(f"Schedule index {self._schedule_index} out of range")
 
-        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            _LOGGER.error("Error setting schedule state: %s", err)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            raise HomeAssistantError(f"Failed to update schedule: {err}") from err
 
     async def _send_set_schedules_mutation(self, schedule_slots, enabled=None) -> bool:
         """Send the setSchedules mutation to the Andersen EV API."""


### PR DESCRIPTION
## Summary
- Service handlers in __init__.py now raise HomeAssistantError instead of returning error dicts or silently failing
- Lock entity raises HomeAssistantError when lock/unlock commands fail
- Switch entity raises HomeAssistantError when schedule updates fail
- Marks action-exceptions rule as done in quality_scale.yaml

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Existing tests still pass (no behavior change for success paths)
