### PR TITLE
feat: mark charger unavailable when the API is unreachable

### DIFF
--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -144,6 +144,7 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL))
         self.client = client
         self.devices = []
+        self._device_availability: dict[str, bool] = {}
 
     async def async_request_refresh(self) -> None:
         """Request a data refresh after a short delay.
@@ -192,8 +193,27 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
                 "Device ID: %s, Name: %s, User Lock: %s", device.device_id, device.friendly_name, device.user_lock
             )
             try:
-                await device.get_detailed_device_status()
-            except UpdateFailed:
-                _LOGGER.debug("Error getting status for %s", device.friendly_name)
+                status = await device.get_detailed_device_status()
+            except Exception as err:  # noqa: BLE001
+                self._mark_device_unavailable(device, err)
+                continue
+
+            if status is None:
+                self._mark_device_unavailable(device, "no status returned")
+                continue
+
+            device.status_available = True
+            if self._device_availability.get(device.device_id) is False:
+                _LOGGER.info("Device %s is back online", device.friendly_name)
+            self._device_availability[device.device_id] = True
 
         return self.devices
+
+    def _mark_device_unavailable(self, device, error) -> None:
+        """Mark a device unavailable and log once per transition."""
+        device.status_available = False
+        if self._device_availability.get(device.device_id, True):
+            _LOGGER.warning("Device %s is unavailable: %s", device.friendly_name, error)
+        else:
+            _LOGGER.debug("Device %s still unavailable: %s", device.friendly_name, error)
+        self._device_availability[device.device_id] = False

--- a/custom_components/andersen_ev/konnect/device.py
+++ b/custom_components/andersen_ev/konnect/device.py
@@ -28,6 +28,7 @@ class KonnectDevice:
         self._last_status = None
         self.model_name = None
         self._graphql_client = None
+        self.status_available = True
 
     @property
     def last_status(self):

--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -75,7 +75,7 @@ class AndersenEvLock(CoordinatorEntity, LockEntity):  # pylint: disable=abstract
                 self._device = device
                 # Try to update model info if we have device status
                 self._update_model_from_device_status()
-                return True
+                return self.coordinator.last_update_success and self._device.status_available
 
         # Device no longer exists
         return False

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -30,9 +30,9 @@ rules:
   config-entry-unloading: todo
   docs-configuration-parameters: todo
   docs-installation-parameters: todo
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: todo
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: todo
   reauthentication-flow: done
   test-coverage: todo

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -475,7 +475,7 @@ class AndersenEvConnectorSensor(CoordinatorEntity, SensorEntity):
         for device in self.coordinator.data:
             if device.device_id == self._device.device_id:
                 self._device = device
-                return self.coordinator.last_update_success
+                return self.coordinator.last_update_success and self._device.status_available
         return False
 
     @property
@@ -610,7 +610,7 @@ class AndersenEvChargeStatusSensor(CoordinatorEntity, SensorEntity):
                 self._device = device
                 # Check if chargeStatus exists in last_status
                 if self._device.last_status and "chargeStatus" in self._device.last_status:
-                    return self.coordinator.last_update_success
+                    return self.coordinator.last_update_success and self._device.status_available
         return False
 
     @property
@@ -718,7 +718,7 @@ class AndersenEvLiveSensor(CoordinatorEntity, SensorEntity):
                 self._device = device
                 if self._device.last_status and self._data_key in self._device.last_status:
                     _LOGGER.debug("Live available for %s is %s", self._data_key, self.coordinator.last_update_success)
-                    return self.coordinator.last_update_success
+                    return self.coordinator.last_update_success and self._device.status_available
         return False
 
     @property

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -115,7 +115,7 @@ class AndersenEvScheduleSwitch(CoordinatorEntity, SwitchEntity):  # pylint: disa
         for device in self.coordinator.data:
             if device.device_id == self._device.device_id:
                 self._device = device
-                return self.coordinator.last_update_success
+                return self.coordinator.last_update_success and self._device.status_available
         return False
 
     @property


### PR DESCRIPTION
## Summary
- Add per-device `status_available` flag on `KonnectDevice` to track whether the most recent status fetch succeeded
- Gate all entity `available` properties on `device.status_available` so entities go unavailable when the API is unreachable
- Implement log-once pattern in the coordinator: warn on first failure, info on recovery, debug on repeated failures
- Mark `entity-unavailable` and `log-when-unavailable` quality scale rules as done

## Test plan
- [ ] CI passes (lint + tests on Python 3.13/3.14)
- [ ] No regressions in entity behavior when API is healthy
- [ ] Entities correctly go unavailable when status fetch fails
