### PR TITLE
feat: allow concurrent entity updates per platform

### DIFF
--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 
+PARALLEL_UPDATES = 1
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   entity-unavailable: done
   integration-owner: todo
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo
 

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -24,6 +24,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 
+PARALLEL_UPDATES = 0
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -16,6 +16,8 @@ from . import AndersenEvConfigEntry, AndersenEvCoordinator
 from .const import DOMAIN
 from .konnect import const
 
+PARALLEL_UPDATES = 1
+
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- Add `PARALLEL_UPDATES = 0` to `sensor.py` (read-only coordinator entities)
- Add `PARALLEL_UPDATES = 1` to `lock.py` and `switch.py` (serializes write operations through the shared GraphQL client)
- Mark `parallel-updates` rule as done in `quality_scale.yaml`

## Test plan
- [ ] CI passes (lint + tests green)
- [ ] No functional change - this only tells HA how to schedule concurrent entity updates
