### PR TITLE
ci: enforce 95% coverage floor and claim Silver quality scale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: uv pip install -r requirements-dev.txt
       - name: Test with pytest
-        run: uv run pytest --cov=custom_components/andersen_ev --cov-report=term-missing --cov-report=xml
+        run: uv run pytest --cov=custom_components/andersen_ev --cov-report=term-missing --cov-report=xml --cov-fail-under=95
 
   hassfest:
     name: Hassfest

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 ## Status
 ![CI](https://github.com/HA-AndersenEV/hassio-andersen-ev/actions/workflows/ci.yml/badge.svg?branch=main)
-![HA Quality Scale: Bronze](https://img.shields.io/badge/HA_Quality_Scale-Bronze-cd7f32)
+![HA Quality Scale: Silver](https://img.shields.io/badge/HA_Quality_Scale-Silver-c0c0c0)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/HA-AndersenEV/hassio-andersen-ev)](https://github.com/HA-AndersenEV/hassio-andersen-ev/releases)
-[![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.andersen_ev.total)
+![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.andersen_ev.total)
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/custom_components/andersen_ev/manifest.json
+++ b/custom_components/andersen_ev/manifest.json
@@ -12,7 +12,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/HA-AndersenEV/hassio-andersen-ev/issues",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": [
     "pycognito",
     "gql[aiohttp]",

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -27,15 +27,15 @@ rules:
 
   # Silver
   action-exceptions: done
-  config-entry-unloading: todo
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
-  integration-owner: todo
+  integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: todo


### PR DESCRIPTION
## Summary
- Add `--cov-fail-under=95` to the CI test job (coverage is now a hard gate)
- Mark all Silver quality scale rules as done
- Set `quality_scale: silver` in manifest.json

## Test plan
- [ ] CI passes with 95% coverage floor enforced
- [ ] Hassfest validates the updated manifest and quality_scale.yaml
