### PR TITLE
feat: downloadable diagnostics with redacted credentials

### DIFF
--- a/custom_components/andersen_ev/diagnostics.py
+++ b/custom_components/andersen_ev/diagnostics.py
@@ -1,0 +1,54 @@
+"""Diagnostics support for Andersen EV."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from . import AndersenEvConfigEntry
+from .konnect.device import KonnectDevice
+
+TO_REDACT = {"email", "password", "token", "refreshToken", "deviceKey"}
+
+
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: AndersenEvConfigEntry) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    devices = coordinator.devices
+
+    client_diagnostics = _client_diagnostics(devices[0].api) if devices else None
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "client": client_diagnostics,
+        "devices": [_device_diagnostics(device) for device in devices],
+    }
+
+
+def _device_diagnostics(device: KonnectDevice) -> dict[str, Any]:
+    """Build a redacted diagnostics dict for a single device."""
+    data = {
+        "device_id": device.device_id,
+        "friendly_name": device.friendly_name,
+        "user_lock": device.user_lock,
+        "status_available": device.status_available,
+        "model_name": device.model_name,
+        "last_status": device.last_status,
+    }
+    return async_redact_data(data, TO_REDACT)
+
+
+def _client_diagnostics(api) -> dict[str, Any]:
+    """Build a redacted diagnostics dict for the shared Konnect auth client."""
+    data = {
+        "email": api.email,
+        "token": api.token,
+        "tokenType": api.tokenType,
+        "tokenExpiresIn": api.tokenExpiresIn,
+        "tokenExpiryTime": api.tokenExpiryTime,
+        "refreshToken": api.refreshToken,
+        "deviceKey": api.deviceKey,
+    }
+    return async_redact_data(data, TO_REDACT)

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -39,7 +39,7 @@ rules:
 
   # Gold
   devices: todo
-  diagnostics: todo
+  diagnostics: done
   discovery:
     status: exempt
     comment: Cloud-only integration; no local/network discovery.

--- a/custom_components/andersen_ev/tests/test_diagnostics.py
+++ b/custom_components/andersen_ev/tests/test_diagnostics.py
@@ -1,0 +1,81 @@
+"""Tests for the Andersen EV diagnostics platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from andersen_ev.diagnostics import async_get_config_entry_diagnostics
+
+
+def _make_entry(devices):
+    """Build a fake AndersenEvConfigEntry with runtime_data.devices set."""
+    entry = MagicMock()
+    entry.data = {"email": "test@example.com", "password": "supersecret"}
+    entry.runtime_data = MagicMock(devices=devices)
+    return entry
+
+
+class TestAsyncGetConfigEntryDiagnostics:
+    """Tests for async_get_config_entry_diagnostics()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_expected_top_level_keys(self, mock_device):
+        entry = _make_entry([mock_device])
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert set(result) == {"entry_data", "client", "devices"}
+        assert len(result["devices"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sensitive_fields_are_redacted(self, mock_device, mock_api):
+        mock_api.email = "secret@example.com"
+        mock_api.refreshToken = "refresh-secret"
+        mock_api.deviceKey = "device-key-secret"
+        entry = _make_entry([mock_device])
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert result["entry_data"]["email"] == "**REDACTED**"
+        assert result["entry_data"]["password"] == "**REDACTED**"
+        assert result["client"]["email"] == "**REDACTED**"
+        assert result["client"]["token"] == "**REDACTED**"
+        assert result["client"]["refreshToken"] == "**REDACTED**"
+        assert result["client"]["deviceKey"] == "**REDACTED**"
+
+    @pytest.mark.asyncio
+    async def test_non_sensitive_fields_pass_through_unredacted(self, mock_device):
+        mock_device.model_name = "Andersen A2"
+        mock_device._last_status = {"online": True}
+        entry = _make_entry([mock_device])
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        device_diag = result["devices"][0]
+        assert device_diag["device_id"] == "test_device_123"
+        assert device_diag["friendly_name"] == "Test Device"
+        assert device_diag["model_name"] == "Andersen A2"
+        assert device_diag["last_status"] == {"online": True}
+        assert result["client"]["tokenType"] == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_no_devices_returns_empty_list_and_no_client_block(self):
+        entry = _make_entry([])
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert result["devices"] == []
+        assert result["client"] is None
+
+    @pytest.mark.asyncio
+    async def test_client_block_not_duplicated_per_device(self, mock_api):
+        from andersen_ev.konnect.device import KonnectDevice
+
+        device_a = KonnectDevice(api=mock_api, device_id="a", friendly_name="A", user_lock=False)
+        device_b = KonnectDevice(api=mock_api, device_id="b", friendly_name="B", user_lock=False)
+        entry = _make_entry([device_a, device_b])
+
+        result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+        assert len(result["devices"]) == 2
+        assert isinstance(result["client"], dict)


### PR DESCRIPTION
## What this does

Adds a downloadable diagnostics file for the integration (Settings > Devices & services > Andersen EV > the three dot menu > Download diagnostics). This is a standard Home Assistant feature that makes it much easier to get useful troubleshooting information from a user without asking them to dig through logs or share their password.

The diagnostics file includes:
- The stored config entry data (email and password)
- The Konnect auth and token state (email, token, token type, expiry info, refresh token, device key)
- Per device status (device id, friendly name, lock state, availability, model, last known status)

Sensitive fields (email, password, token, refresh token, device key) are automatically redacted before the file is generated, so it is safe to share when asking for support.

This closes out the `diagnostics` item on the Gold tier of the quality scale roadmap (tracked in `.handoff/CICD_PLATINUM_ROADMAP.md`, not part of this PR).

## Testing

Full test suite passes locally in Docker: 301 passed, 99.66% coverage (gate is 95%). The new `diagnostics.py` module itself has 100% coverage.
