### PR TITLE
fix: stop PR title check from getting stuck on rapid rebases

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What this fixes

The "Validate PR title" check (PR lint workflow) can get stuck pending forever when a PR
branch is pushed to more than once in quick succession, for example when dependabot rebases
or recreates a PR right after another one merges.

The workflow's concurrency group was keyed only by PR number:

    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

That means every push to the same PR shares one concurrency slot regardless of which commit
it's for. When two pushes land close together, GitHub can cancel the run for the branch's
final commit instead of the outdated one, leaving that check permanently cancelled with no
automatic retry, and blocking merge on `Validate PR title` even though nothing is actually
wrong with the PR.

This happened today merging the dependabot PRs (bumps #82/#83): recreate + a follow up rebase
in short order left the check stuck pending and had to be re-run by hand.

## The fix

Key the concurrency group by commit SHA as well as PR number:

    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

Runs for different commits no longer share a slot, so a fast follow up push can't cancel the
in progress run for the commit that actually ends up as the PR's head. Duplicate events for
the exact same commit still dedupe as before.

No functional change to what the check does, just how it dedupes.
