### PR TITLE
feat: classify schedule switches and diagnostic sensors

### DIFF
--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -54,9 +54,9 @@ rules:
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices: done
-  entity-category: todo
-  entity-device-class: todo
-  entity-disabled-by-default: todo
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
   entity-translations: todo
   exception-translations: todo
   icon-translations: todo

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -154,6 +154,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             None,
             None,
             "mdi:exclamation",
+            entity_category=EntityCategory.DIAGNOSTIC,
         )
     )
     entities.append(
@@ -167,6 +168,8 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             SensorStateClass.TOTAL,
             UnitOfEnergy.KILO_WATT_HOUR,
             "mdi:transmission-tower",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            enabled_default=False,
         )
     )
 
@@ -652,6 +655,8 @@ class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
         state_class=None,
         unit=None,
         icon=None,
+        entity_category: EntityCategory | None = None,
+        enabled_default: bool = True,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -675,6 +680,9 @@ class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
             self._attr_native_unit_of_measurement = unit
         if icon:
             self._attr_icon = icon
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
+        self._attr_entity_registry_enabled_default = enabled_default
         self._update_model_from_device_status()
 
     @property

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -103,6 +103,7 @@ class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, Swi
     """Representation of an Andersen EV charging schedule switch."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/andersen_ev/tests/test_sensor.py
+++ b/custom_components/andersen_ev/tests/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.helpers.entity import EntityCategory
 
 from andersen_ev.sensor import (
     AndersenEvChargeStatusSensor,
@@ -12,6 +13,7 @@ from andersen_ev.sensor import (
     AndersenEvCostSensor,
     AndersenEvEnergySensor,
     AndersenEvLiveSensor,
+    _build_entities_for_device,
     async_setup_entry,
 )
 
@@ -868,6 +870,52 @@ class TestLiveSensorInit:
         assert sensor._attr_native_unit_of_measurement == UnitOfPower.KILO_WATT
         assert sensor._attr_icon == "mdi:transmission-tower"
 
+    def test_entity_category_set_when_provided(self):
+        device = _make_device()
+        coordinator = _make_coordinator([device])
+
+        sensor = AndersenEvLiveSensor(
+            coordinator,
+            device,
+            "sys_fault_code",
+            "Fault Code",
+            "sysFaultCode",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+
+        assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_entity_category_none_by_default(self):
+        device = _make_device()
+        coordinator = _make_coordinator([device])
+
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+
+        assert sensor.entity_category is None
+
+    def test_enabled_default_true_by_default(self):
+        device = _make_device()
+        coordinator = _make_coordinator([device])
+
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+
+        assert sensor.entity_registry_enabled_default is True
+
+    def test_enabled_default_false_when_provided(self):
+        device = _make_device()
+        coordinator = _make_coordinator([device])
+
+        sensor = AndersenEvLiveSensor(
+            coordinator,
+            device,
+            "sys_grid_energy_delta",
+            "System Grid Energy Delta",
+            "sysGridEnergyDelta",
+            enabled_default=False,
+        )
+
+        assert sensor.entity_registry_enabled_default is False
+
 
 class TestLiveSensorAvailable:
     """Tests for AndersenEvLiveSensor.available."""
@@ -978,6 +1026,51 @@ class TestLiveSensorAsyncUpdate:
         sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
 
         await sensor.async_update()
+
+
+class TestBuildEntitiesForDeviceEntityCategories:
+    """Tests locking in per-instance entity_category/enabled_default overrides."""
+
+    def _entities_by_unique_id_suffix(self, device):
+        coordinator = _make_coordinator([device])
+        entities = _build_entities_for_device(coordinator, device)
+        return {entity._attr_unique_id.removeprefix(f"{device.device_id}_"): entity for entity in entities}
+
+    def test_fault_code_sensor_is_diagnostic(self):
+        device = _make_device()
+        entities = self._entities_by_unique_id_suffix(device)
+
+        sensor = entities["sys_fault_code"]
+
+        assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+        assert sensor.entity_registry_enabled_default is True
+
+    def test_grid_energy_delta_sensor_is_diagnostic_and_disabled_by_default(self):
+        device = _make_device()
+        entities = self._entities_by_unique_id_suffix(device)
+
+        sensor = entities["sys_grid_energy_delta"]
+
+        assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+        assert sensor.entity_registry_enabled_default is False
+
+    def test_unrelated_live_sensor_is_uncategorized_and_enabled(self):
+        device = _make_device()
+        entities = self._entities_by_unique_id_suffix(device)
+
+        sensor = entities["sys_grid_power"]
+
+        assert sensor.entity_category is None
+        assert sensor.entity_registry_enabled_default is True
+
+    def test_unrelated_energy_sensor_is_uncategorized_and_enabled(self):
+        device = _make_device()
+        entities = self._entities_by_unique_id_suffix(device)
+
+        sensor = entities["energy"]
+
+        assert sensor.entity_category is None
+        assert sensor.entity_registry_enabled_default is True
 
 
 class TestEnergySensorUnitConstants:

--- a/custom_components/andersen_ev/tests/test_switch.py
+++ b/custom_components/andersen_ev/tests/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
 
 from andersen_ev.switch import AndersenEvScheduleSwitch, async_setup_entry
 
@@ -271,6 +272,14 @@ class TestInit:
         assert switch._attr_icon == "mdi:calendar-clock"
         assert switch._attr_device_info["name"] == "My Charger (device_1)"
         assert switch._attr_has_entity_name is True
+
+    def test_entity_category_is_config(self):
+        device = _make_device()
+        coordinator = _make_coordinator([device])
+
+        switch = _make_switch(coordinator, device)
+
+        assert switch.entity_category == EntityCategory.CONFIG
 
     def test_extra_state_attributes(self):
         device = _make_device()


### PR DESCRIPTION
## What this does

Classifies existing entities by category and device class (Home Assistant Gold quality tier, item G3).

- Schedule enable/disable switches now show under the device's configuration section instead of next to main sensors.
- The raw fault code sensor is marked as diagnostic info.
- The grid energy delta sensor is marked as diagnostic and hidden from the dashboard by default, since it duplicates the existing cumulative grid energy sensor and most users won't need both.
- Confirmed every other sensor already reports the correct device class (power, energy, temperature, voltage, monetary, timestamp, etc.) so nothing else needed changing there.

No new entities, no behavior changes to charging, locking, or scheduling. Anyone who wants the grid energy delta sensor back can just re-enable it from the entity settings.

## Testing

- Full suite: 330 passed, 99.66% coverage (sensor.py and switch.py at 100%).
- New tests lock in the category/enabled defaults for the changed entities and confirm unrelated entities are unaffected.
- ruff check and format clean on all changed files.

## Roadmap tracking

Updates `quality_scale.yaml`: entity-category, entity-device-class, entity-disabled-by-default all move from todo to done.
