### PR TITLE
feat: translatable entity names, icons, and error messages

### DIFF
--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -80,7 +80,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 await coordinator.async_request_refresh()
                 break
         else:
-            raise HomeAssistantError(f"Device {device_id} not found")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
 
     async def get_device_info(call: ServiceCall) -> dict:
         """Get detailed information for a device and return it to the UI."""
@@ -93,9 +97,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 if device_info:
                     # Return the device info as a response that will be shown in the UI
                     return device_info
-                raise HomeAssistantError("Failed to retrieve device information")
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="get_device_info_failed",
+                    translation_placeholders={"device_id": device_id},
+                )
 
-        raise HomeAssistantError(f"Device {device_id} not found")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"device_id": device_id},
+        )
 
     async def get_device_status(call: ServiceCall) -> dict:
         """Get detailed status for a device and return it to the UI."""
@@ -107,9 +119,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 device_status = await device.get_detailed_device_status()
                 if device_status:
                     return device_status
-                raise HomeAssistantError("Failed to retrieve device status")
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="get_device_status_failed",
+                    translation_placeholders={"device_id": device_id},
+                )
 
-        raise HomeAssistantError(f"Device {device_id} not found")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"device_id": device_id},
+        )
 
     async def reset_rcm(call: ServiceCall) -> None:
         """Reset RCM fault for a device."""
@@ -122,7 +142,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 await coordinator.async_request_refresh()
                 break
         else:
-            raise HomeAssistantError(f"Device {device_id} not found")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
 
     # Register services using simpler schema
     service_schema = vol.Schema({vol.Required(ATTR_DEVICE_ID): str})

--- a/custom_components/andersen_ev/icons.json
+++ b/custom_components/andersen_ev/icons.json
@@ -1,0 +1,31 @@
+{
+  "entity": {
+    "sensor": {
+      "energy": { "default": "mdi:lightning-bolt-circle" },
+      "grid_energy": { "default": "mdi:transmission-tower" },
+      "solar_energy": { "default": "mdi:solar-power" },
+      "surplus_energy": { "default": "mdi:battery-plus" },
+      "sys_grid_power": { "default": "mdi:transmission-tower" },
+      "sys_temperature": { "default": "mdi:temperature-celsius" },
+      "sys_voltage": { "default": "mdi:transmission-tower" },
+      "sys_fault_code": { "default": "mdi:exclamation" },
+      "sys_grid_energy_delta": { "default": "mdi:transmission-tower" },
+      "cost": { "default": "mdi:currency-gbp" },
+      "grid_cost": { "default": "mdi:cash-multiple" },
+      "solar_cost": { "default": "mdi:solar-power-variant" },
+      "surplus_cost": { "default": "mdi:cash-plus" },
+      "connector": { "default": "mdi:ev-plug-type2" },
+      "charge_power": { "default": "mdi:ev-station" },
+      "charge_power_max": { "default": "mdi:speedometer" },
+      "solar_power": { "default": "mdi:solar-power" },
+      "grid_power": { "default": "mdi:transmission-tower" },
+      "current_charge_energy": { "default": "mdi:car-electric" },
+      "current_solar_energy": { "default": "mdi:solar-power-variant" },
+      "current_grid_energy": { "default": "mdi:power-plug" },
+      "session_start": { "default": "mdi:clock-start" }
+    },
+    "switch": {
+      "schedule": { "default": "mdi:calendar-clock" }
+    }
+  }
+}

--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -50,13 +50,13 @@ class AndersenEvLock(AndersenEvDeviceInfoMixin, CoordinatorEntity, LockEntity): 
     """Representation of an Andersen EV charging lock."""
 
     _attr_has_entity_name = True
+    _attr_translation_key = "lock"
 
     def __init__(self, coordinator: AndersenEvCoordinator, device) -> None:
         """Initialize the lock."""
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.device_id}_lock"
-        self._attr_name = "Lock"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
             name=f"{device.friendly_name} ({device.device_id})",
@@ -111,13 +111,21 @@ class AndersenEvLock(AndersenEvDeviceInfoMixin, CoordinatorEntity, LockEntity): 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the charging station (disable charging)."""
         if not await self._device.disable():
-            raise HomeAssistantError("Failed to lock the charger")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="lock_failed",
+                translation_placeholders={"device_name": self._device.friendly_name},
+            )
         _LOGGER.debug("Locking device %s (disabling charging)", self._device.friendly_name)
         await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the charging station (enable charging)."""
         if not await self._device.enable():
-            raise HomeAssistantError("Failed to unlock the charger")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unlock_failed",
+                translation_placeholders={"device_name": self._device.friendly_name},
+            )
         _LOGGER.debug("Unlocking device %s (enabling charging)", self._device.friendly_name)
         await self.coordinator.async_request_refresh()

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -57,9 +57,9 @@ rules:
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations: todo
-  exception-translations: todo
-  icon-translations: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices: done

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -67,9 +67,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "energy",
-            "Total Energy",
             "chargeEnergyTotal",
-            "mdi:lightning-bolt-circle",
         )
     )
     entities.append(
@@ -77,9 +75,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "grid_energy",
-            "Grid Energy",
             "gridEnergyTotal",
-            "mdi:transmission-tower",
         )
     )
     entities.append(
@@ -87,9 +83,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "solar_energy",
-            "Solar Energy",
             "solarEnergyTotal",
-            "mdi:solar-power",
         )
     )
     entities.append(
@@ -97,9 +91,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "surplus_energy",
-            "Surplus Energy",
             "surplusUsedEnergyTotal",
-            "mdi:battery-plus",
         )
     )
 
@@ -109,12 +101,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "sys_grid_power",
-            "System Grid Power",
             "sysGridPower",
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             UnitOfPower.KILO_WATT,
-            "mdi:transmission-tower",
         )
     )
     entities.append(
@@ -122,12 +112,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "sys_temperature",
-            "System Temperature",
             "sysTemperature",
             SensorDeviceClass.TEMPERATURE,
             SensorStateClass.MEASUREMENT,
             UnitOfTemperature.CELSIUS,
-            "mdi:temperature-celsius",
         )
     )
     entities.append(
@@ -135,12 +123,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "sys_voltage",
-            "System Voltage",
             "sysVoltageC",
             SensorDeviceClass.VOLTAGE,
             SensorStateClass.MEASUREMENT,
             UnitOfElectricPotential.VOLT,
-            "mdi:transmission-tower",
         )
     )
     entities.append(
@@ -148,12 +134,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "sys_fault_code",
-            "Fault Code",
             "sysFaultCode",
             None,
             None,
             None,
-            "mdi:exclamation",
             entity_category=EntityCategory.DIAGNOSTIC,
         )
     )
@@ -162,12 +146,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "sys_grid_energy_delta",
-            "System Grid Energy Delta",
             "sysGridEnergyDelta",
             SensorDeviceClass.ENERGY,
             SensorStateClass.TOTAL,
             UnitOfEnergy.KILO_WATT_HOUR,
-            "mdi:transmission-tower",
             entity_category=EntityCategory.DIAGNOSTIC,
             enabled_default=False,
         )
@@ -179,9 +161,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "cost",
-            "Total Cost",
             "chargeCostTotal",
-            "mdi:currency-gbp",
         )
     )
     entities.append(
@@ -189,9 +169,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "grid_cost",
-            "Grid Cost",
             "gridCostTotal",
-            "mdi:cash-multiple",
         )
     )
     entities.append(
@@ -199,9 +177,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "solar_cost",
-            "Solar Cost",
             "solarCostTotal",
-            "mdi:solar-power-variant",
         )
     )
     entities.append(
@@ -209,9 +185,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "surplus_cost",
-            "Surplus Cost",
             "surplusUsedCostTotal",
-            "mdi:cash-plus",
         )
     )
 
@@ -224,12 +198,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             UnitOfPower.WATT,
-            "mdi:ev-station",
         )
     )
     entities.append(
@@ -237,12 +209,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "charge_power_max",
-            "Max Charge Power",
             "chargePowerMax",
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             UnitOfPower.KILO_WATT,
-            "mdi:speedometer",
         )
     )
     entities.append(
@@ -250,12 +220,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "solar_power",
-            "Solar Power",
             "solarPower",
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             UnitOfPower.WATT,
-            "mdi:solar-power",
         )
     )
     entities.append(
@@ -263,12 +231,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "grid_power",
-            "Grid Power",
             "gridPower",
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             UnitOfPower.WATT,
-            "mdi:transmission-tower",
         )
     )
 
@@ -278,12 +244,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "current_charge_energy",
-            "Current Session Energy",
             "chargeEnergyTotal",
             SensorDeviceClass.ENERGY,
             SensorStateClass.TOTAL,
             UnitOfEnergy.KILO_WATT_HOUR,
-            "mdi:car-electric",
         )
     )
     entities.append(
@@ -291,12 +255,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "current_solar_energy",
-            "Current Session Solar Energy",
             "solarEnergyTotal",
             SensorDeviceClass.ENERGY,
             SensorStateClass.TOTAL,
             UnitOfEnergy.KILO_WATT_HOUR,
-            "mdi:solar-power-variant",
         )
     )
     entities.append(
@@ -304,12 +266,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "current_grid_energy",
-            "Current Session Grid Energy",
             "gridEnergyTotal",
             SensorDeviceClass.ENERGY,
             SensorStateClass.TOTAL,
             UnitOfEnergy.KILO_WATT_HOUR,
-            "mdi:power-plug",
         )
     )
 
@@ -319,12 +279,10 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
             coordinator,
             device,
             "session_start",
-            "Session Start Time",
             "start",
             SensorDeviceClass.TIMESTAMP,
             None,
             None,
-            "mdi:clock-start",
         )
     )
 
@@ -336,13 +294,13 @@ class AndersenEvBaseSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: AndersenEvCoordinator, device, sensor_type, name_suffix, data_key=None) -> None:
+    def __init__(self, coordinator: AndersenEvCoordinator, device, sensor_type, data_key=None) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = name_suffix
+        self._attr_translation_key = sensor_type
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
@@ -390,13 +348,9 @@ class AndersenEvEnergySensor(AndersenEvBaseSensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 
-    def __init__(
-        self, coordinator: AndersenEvCoordinator, device, sensor_type, name_suffix, data_key, icon=None
-    ) -> None:
+    def __init__(self, coordinator: AndersenEvCoordinator, device, sensor_type, data_key) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, device, sensor_type, name_suffix, data_key)
-        if icon:
-            self._attr_icon = icon
+        super().__init__(coordinator, device, sensor_type, data_key)
 
     @property
     def native_value(self) -> float | None:
@@ -414,13 +368,9 @@ class AndersenEvCostSensor(AndersenEvBaseSensor):
     # Assuming GBP - you could make this configurable
     _attr_native_unit_of_measurement = "GBP"
 
-    def __init__(
-        self, coordinator: AndersenEvCoordinator, device, sensor_type, name_suffix, data_key, icon=None
-    ) -> None:
+    def __init__(self, coordinator: AndersenEvCoordinator, device, sensor_type, data_key) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, device, sensor_type, name_suffix, data_key)
-        if icon:
-            self._attr_icon = icon
+        super().__init__(coordinator, device, sensor_type, data_key)
 
     @property
     def native_value(self) -> float | None:
@@ -445,12 +395,12 @@ class AndersenEvConnectorSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, Se
     ]
 
     _attr_has_entity_name = True
+    _attr_translation_key = "connector"
 
-    def __init__(self, coordinator: AndersenEvCoordinator, device, icon=None) -> None:
+    def __init__(self, coordinator: AndersenEvCoordinator, device) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
-        self._attr_name = "Connector"
         self._attr_unique_id = f"{device.device_id}_connector"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
@@ -459,10 +409,6 @@ class AndersenEvConnectorSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, Se
             model="A2",
             serial_number=f"{device.device_id}",
         )
-        if icon:
-            self._attr_icon = icon
-        else:
-            self._attr_icon = "mdi:ev-plug-type2"
         self._update_model_from_device_status()
         self._connector_state = "unknown"
         self._last_evse_state = None
@@ -555,19 +501,17 @@ class AndersenEvChargeStatusSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity,
         coordinator: AndersenEvCoordinator,
         device,
         sensor_type,
-        name_suffix,
         data_key,
         device_class=None,
         state_class=None,
         unit=None,
-        icon=None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = name_suffix
+        self._attr_translation_key = sensor_type
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
@@ -582,8 +526,6 @@ class AndersenEvChargeStatusSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity,
             self._attr_state_class = state_class
         if unit:
             self._attr_native_unit_of_measurement = unit
-        if icon:
-            self._attr_icon = icon
         self._update_model_from_device_status()
 
     @property
@@ -649,12 +591,10 @@ class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
         coordinator: AndersenEvCoordinator,
         device,
         sensor_type,
-        name_suffix,
         data_key,
         device_class=None,
         state_class=None,
         unit=None,
-        icon=None,
         entity_category: EntityCategory | None = None,
         enabled_default: bool = True,
     ) -> None:
@@ -663,7 +603,7 @@ class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
         self._device = device
         self._sensor_type = sensor_type
         self._data_key = data_key
-        self._attr_name = name_suffix
+        self._attr_translation_key = sensor_type
         self._attr_unique_id = f"{device.device_id}_{sensor_type}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
@@ -678,8 +618,6 @@ class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorE
             self._attr_state_class = state_class
         if unit:
             self._attr_native_unit_of_measurement = unit
-        if icon:
-            self._attr_icon = icon
         if entity_category is not None:
             self._attr_entity_category = entity_category
         self._attr_entity_registry_enabled_default = enabled_default

--- a/custom_components/andersen_ev/strings.json
+++ b/custom_components/andersen_ev/strings.json
@@ -26,5 +26,48 @@
       "already_configured": "This account is already configured",
       "reauth_successful": "Re-authentication successful"
     }
+  },
+  "entity": {
+    "sensor": {
+      "energy": { "name": "Total Energy" },
+      "grid_energy": { "name": "Grid Energy" },
+      "solar_energy": { "name": "Solar Energy" },
+      "surplus_energy": { "name": "Surplus Energy" },
+      "sys_grid_power": { "name": "System Grid Power" },
+      "sys_temperature": { "name": "System Temperature" },
+      "sys_voltage": { "name": "System Voltage" },
+      "sys_fault_code": { "name": "Fault Code" },
+      "sys_grid_energy_delta": { "name": "System Grid Energy Delta" },
+      "cost": { "name": "Total Cost" },
+      "grid_cost": { "name": "Grid Cost" },
+      "solar_cost": { "name": "Solar Cost" },
+      "surplus_cost": { "name": "Surplus Cost" },
+      "connector": { "name": "Connector" },
+      "charge_power": { "name": "Charge Power" },
+      "charge_power_max": { "name": "Max Charge Power" },
+      "solar_power": { "name": "Solar Power" },
+      "grid_power": { "name": "Grid Power" },
+      "current_charge_energy": { "name": "Current Session Energy" },
+      "current_solar_energy": { "name": "Current Session Solar Energy" },
+      "current_grid_energy": { "name": "Current Session Grid Energy" },
+      "session_start": { "name": "Session Start Time" }
+    },
+    "switch": {
+      "schedule": { "name": "Schedule {index}" }
+    },
+    "lock": {
+      "lock": { "name": "Lock" }
+    }
+  },
+  "exceptions": {
+    "device_not_found": { "message": "Device {device_id} not found" },
+    "get_device_info_failed": { "message": "Failed to retrieve device information for {device_id}" },
+    "get_device_status_failed": { "message": "Failed to retrieve device status for {device_id}" },
+    "lock_failed": { "message": "Failed to lock the charger {device_name}" },
+    "unlock_failed": { "message": "Failed to unlock the charger {device_name}" },
+    "schedule_data_unavailable": { "message": "Failed to retrieve schedule data for {device_name}" },
+    "schedule_update_failed": { "message": "Failed to update schedule for {device_name}" },
+    "schedule_index_out_of_range": { "message": "Schedule index {index} is out of range for {device_name}" },
+    "schedule_update_error": { "message": "Failed to update schedule for {device_name}: {error}" }
   }
 }

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -117,7 +117,8 @@ class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, Swi
         self._device = device
         self._schedule_index = index
         self._schedule_name = schedule_name
-        self._attr_name = f"Schedule {index + 1}"
+        self._attr_translation_key = "schedule"
+        self._attr_translation_placeholders = {"index": str(index + 1)}
         self._attr_unique_id = f"{device.device_id}_schedule_{index}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
@@ -126,7 +127,6 @@ class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, Swi
             model="A2",
             serial_number=f"{device.device_id}",
         )
-        self._attr_icon = "mdi:calendar-clock"
         self._update_model_from_device_status()
 
     @property
@@ -190,7 +190,11 @@ class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, Swi
                     or "deviceStatus" not in device_info
                     or "scheduleSlotsArray" not in device_info["deviceStatus"]
                 ):
-                    raise HomeAssistantError("Failed to retrieve schedule data")
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="schedule_data_unavailable",
+                        translation_placeholders={"device_name": self._device.friendly_name},
+                    )
                 schedule_slots = copy.deepcopy(device_info["deviceStatus"]["scheduleSlotsArray"])
             else:
                 # Use the data from the coordinator
@@ -227,12 +231,27 @@ class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, Swi
                     # Request a refresh of the coordinator data to update all entities
                     await self.coordinator.async_request_refresh()
                 else:
-                    raise HomeAssistantError(f"Failed to update schedule for {self._device.friendly_name}")
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="schedule_update_failed",
+                        translation_placeholders={"device_name": self._device.friendly_name},
+                    )
             else:
-                raise HomeAssistantError(f"Schedule index {self._schedule_index} out of range")
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="schedule_index_out_of_range",
+                    translation_placeholders={
+                        "index": str(self._schedule_index),
+                        "device_name": self._device.friendly_name,
+                    },
+                )
 
         except Exception as err:  # pylint: disable=broad-exception-caught
-            raise HomeAssistantError(f"Failed to update schedule: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_update_error",
+                translation_placeholders={"device_name": self._device.friendly_name, "error": str(err)},
+            ) from err
 
     async def _send_set_schedules_mutation(self, schedule_slots, enabled=None) -> bool:
         """Send the setSchedules mutation to the Andersen EV API."""

--- a/custom_components/andersen_ev/tests/test_lock.py
+++ b/custom_components/andersen_ev/tests/test_lock.py
@@ -148,7 +148,7 @@ class TestInit:
         lock = AndersenEvLock(coordinator, device)
 
         assert lock._attr_unique_id == "device_1_lock"
-        assert lock._attr_name == "Lock"
+        assert lock._attr_translation_key == "lock"
         assert lock._attr_has_entity_name is True
         assert lock._attr_device_info["name"] == "My Charger (device_1)"
         assert lock._attr_device_info["manufacturer"] == "Andersen EV"

--- a/custom_components/andersen_ev/tests/test_sensor.py
+++ b/custom_components/andersen_ev/tests/test_sensor.py
@@ -156,30 +156,12 @@ class TestBaseSensorInit:
         device = _make_device(device_id="device_1", friendly_name="My Charger")
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_unique_id == "device_1_energy"
-        assert sensor._attr_name == "Total Energy"
+        assert sensor._attr_translation_key == "energy"
         assert sensor._attr_device_info["name"] == "My Charger (device_1)"
         assert sensor._attr_has_entity_name is True
-
-    def test_icon_set_when_provided(self):
-        device = _make_device()
-        coordinator = _make_coordinator([device])
-
-        sensor = AndersenEvEnergySensor(
-            coordinator, device, "energy", "Total Energy", "chargeEnergyTotal", icon="mdi:custom"
-        )
-
-        assert sensor._attr_icon == "mdi:custom"
-
-    def test_icon_not_set_when_absent(self):
-        device = _make_device()
-        coordinator = _make_coordinator([device])
-
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
-
-        assert not hasattr(sensor, "_attr_icon")
 
 
 class TestBaseSensorUpdateModelFromDeviceStatus:
@@ -189,7 +171,7 @@ class TestBaseSensorUpdateModelFromDeviceStatus:
         device = _make_device(model_name="Andersen A3")
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_device_info["model"] == "Andersen A3"
 
@@ -197,7 +179,7 @@ class TestBaseSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductName": "Andersen A2 Pro"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_device_info["model"] == "Andersen A2 Pro"
 
@@ -205,7 +187,7 @@ class TestBaseSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductId": "A2"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -213,7 +195,7 @@ class TestBaseSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysHwVersion": "1.5"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_device_info["model"] == "A2 (HW: 1.5)"
 
@@ -221,7 +203,7 @@ class TestBaseSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status=None)
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -232,7 +214,7 @@ class TestBaseSensorAvailable:
     def test_available_when_update_success_and_last_charge_present(self):
         device = _make_device()
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = {"chargeEnergyTotal": 1.0}
 
         assert sensor.available is True
@@ -240,7 +222,7 @@ class TestBaseSensorAvailable:
     def test_unavailable_when_last_charge_none(self):
         device = _make_device()
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = None
 
         assert sensor.available is False
@@ -248,7 +230,7 @@ class TestBaseSensorAvailable:
     def test_unavailable_when_coordinator_update_failed(self):
         device = _make_device()
         coordinator = _make_coordinator([device], last_update_success=False)
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = {"chargeEnergyTotal": 1.0}
 
         assert sensor.available is False
@@ -261,7 +243,7 @@ class TestBaseSensorAsyncAddedToHass:
     async def test_updates_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._update_last_charge = AsyncMock()
 
         await sensor.async_added_to_hass()
@@ -276,7 +258,7 @@ class TestBaseSensorAsyncUpdate:
     async def test_updates_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._update_last_charge = AsyncMock()
 
         await sensor.async_update()
@@ -291,7 +273,7 @@ class TestUpdateLastCharge:
     async def test_fetches_last_charge_and_updates_model(self):
         device = _make_device(last_status={"sysProductName": "Andersen A2 Pro"}, last_charge={"chargeEnergyTotal": 5})
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         await sensor._update_last_charge()
 
@@ -302,7 +284,7 @@ class TestUpdateLastCharge:
     async def test_no_status_skips_model_update(self):
         device = _make_device(last_status=None, last_charge={"chargeEnergyTotal": 5})
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         await sensor._update_last_charge()
 
@@ -315,7 +297,7 @@ class TestEnergySensorNativeValue:
     def test_returns_value_from_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = {"chargeEnergyTotal": 15.5}
 
         assert sensor.native_value == 15.5
@@ -323,7 +305,7 @@ class TestEnergySensorNativeValue:
     def test_returns_none_when_key_missing(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = {"other": 1}
 
         assert sensor.native_value is None
@@ -331,7 +313,7 @@ class TestEnergySensorNativeValue:
     def test_returns_none_when_no_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
         sensor._last_charge = None
 
         assert sensor.native_value is None
@@ -343,7 +325,7 @@ class TestCostSensorNativeValue:
     def test_returns_value_from_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvCostSensor(coordinator, device, "cost", "Total Cost", "chargeCostTotal")
+        sensor = AndersenEvCostSensor(coordinator, device, "cost", "chargeCostTotal")
         sensor._last_charge = {"chargeCostTotal": 4.5}
 
         assert sensor.native_value == 4.5
@@ -351,7 +333,7 @@ class TestCostSensorNativeValue:
     def test_returns_none_when_key_missing(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvCostSensor(coordinator, device, "cost", "Total Cost", "chargeCostTotal")
+        sensor = AndersenEvCostSensor(coordinator, device, "cost", "chargeCostTotal")
         sensor._last_charge = {"other": 1}
 
         assert sensor.native_value is None
@@ -359,39 +341,22 @@ class TestCostSensorNativeValue:
     def test_returns_none_when_no_last_charge(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvCostSensor(coordinator, device, "cost", "Total Cost", "chargeCostTotal")
+        sensor = AndersenEvCostSensor(coordinator, device, "cost", "chargeCostTotal")
         sensor._last_charge = None
 
         assert sensor.native_value is None
-
-    def test_icon_set_when_provided(self):
-        device = _make_device()
-        coordinator = _make_coordinator([device])
-
-        sensor = AndersenEvCostSensor(coordinator, device, "cost", "Total Cost", "chargeCostTotal", icon="mdi:cash")
-
-        assert sensor._attr_icon == "mdi:cash"
 
 
 class TestConnectorSensorInit:
     """Tests for AndersenEvConnectorSensor.__init__()."""
 
-    def test_default_icon(self):
+    def test_default_translation_key(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
 
         sensor = AndersenEvConnectorSensor(coordinator, device)
 
-        assert sensor._attr_icon == "mdi:ev-plug-type2"
-        assert sensor._attr_name == "Connector"
-
-    def test_custom_icon(self):
-        device = _make_device()
-        coordinator = _make_coordinator([device])
-
-        sensor = AndersenEvConnectorSensor(coordinator, device, icon="mdi:custom")
-
-        assert sensor._attr_icon == "mdi:custom"
+        assert sensor._attr_translation_key == "connector"
 
 
 class TestConnectorSensorUpdateModelFromDeviceStatus:
@@ -573,24 +538,21 @@ class TestChargeStatusSensorInit:
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             unit=UnitOfPower.WATT,
-            icon="mdi:ev-station",
         )
 
         assert sensor._attr_device_class == SensorDeviceClass.POWER
         assert sensor._attr_state_class == SensorStateClass.MEASUREMENT
         assert sensor._attr_native_unit_of_measurement == UnitOfPower.WATT
-        assert sensor._attr_icon == "mdi:ev-station"
 
     def test_optional_attributes_omitted_when_absent(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_unique_id == f"{device.device_id}_charge_power"
 
@@ -602,7 +564,7 @@ class TestChargeStatusSensorUpdateModelFromDeviceStatus:
         device = _make_device(model_name="Andersen A3")
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_device_info["model"] == "Andersen A3"
 
@@ -610,7 +572,7 @@ class TestChargeStatusSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductName": "Andersen A2 Pro"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_device_info["model"] == "Andersen A2 Pro"
 
@@ -618,7 +580,7 @@ class TestChargeStatusSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductId": "A2"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -626,7 +588,7 @@ class TestChargeStatusSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysHwVersion": "1.5"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_device_info["model"] == "A2 (HW: 1.5)"
 
@@ -634,7 +596,7 @@ class TestChargeStatusSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status=None)
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -645,28 +607,28 @@ class TestChargeStatusSensorAvailable:
     def test_available_when_charge_status_present(self):
         device = _make_device(last_status={"chargeStatus": {"chargePower": 1000}}, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor.available is True
 
     def test_unavailable_when_charge_status_missing(self):
         device = _make_device(last_status={"other": True}, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor.available is False
 
     def test_unavailable_when_no_status(self):
         device = _make_device(last_status=None, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor.available is False
 
     def test_unavailable_when_device_not_found(self):
         device = _make_device(device_id="device_1")
         coordinator = _make_coordinator([], last_update_success=True)
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         assert sensor.available is False
 
@@ -681,7 +643,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
         )
@@ -695,7 +656,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
         )
@@ -709,7 +669,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
         )
@@ -723,7 +682,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
         )
@@ -737,7 +695,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "session_start",
-            "Session Start Time",
             "start",
             device_class=SensorDeviceClass.TIMESTAMP,
         )
@@ -755,7 +712,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             device,
             "session_start",
-            "Session Start Time",
             "start",
             device_class=SensorDeviceClass.TIMESTAMP,
         )
@@ -770,7 +726,6 @@ class TestChargeStatusSensorNativeValue:
             coordinator,
             original_device,
             "charge_power",
-            "Charge Power",
             "chargePower",
             device_class=SensorDeviceClass.POWER,
         )
@@ -786,7 +741,7 @@ class TestChargeStatusSensorAsyncUpdate:
     async def test_refreshes_from_api(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         await sensor.async_update()
 
@@ -797,7 +752,7 @@ class TestChargeStatusSensorAsyncUpdate:
         device = _make_device()
         device.get_detailed_device_status = AsyncMock(side_effect=RuntimeError("boom"))
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "Charge Power", "chargePower")
+        sensor = AndersenEvChargeStatusSensor(coordinator, device, "charge_power", "chargePower")
 
         await sensor.async_update()
 
@@ -809,7 +764,7 @@ class TestLiveSensorUpdateModelFromDeviceStatus:
         device = _make_device(model_name="Andersen A3")
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor._attr_device_info["model"] == "Andersen A3"
 
@@ -817,7 +772,7 @@ class TestLiveSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductName": "Andersen A2 Pro"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor._attr_device_info["model"] == "Andersen A2 Pro"
 
@@ -825,7 +780,7 @@ class TestLiveSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysProductId": "A2"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -833,7 +788,7 @@ class TestLiveSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status={"sysHwVersion": "1.5"})
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor._attr_device_info["model"] == "A2 (HW: 1.5)"
 
@@ -841,7 +796,7 @@ class TestLiveSensorUpdateModelFromDeviceStatus:
         device = _make_device(last_status=None)
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor._attr_device_info["model"] == "A2"
 
@@ -857,18 +812,15 @@ class TestLiveSensorInit:
             coordinator,
             device,
             "sys_grid_power",
-            "System Grid Power",
             "sysGridPower",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             unit=UnitOfPower.KILO_WATT,
-            icon="mdi:transmission-tower",
         )
 
         assert sensor._attr_device_class == SensorDeviceClass.POWER
         assert sensor._attr_state_class == SensorStateClass.MEASUREMENT
         assert sensor._attr_native_unit_of_measurement == UnitOfPower.KILO_WATT
-        assert sensor._attr_icon == "mdi:transmission-tower"
 
     def test_entity_category_set_when_provided(self):
         device = _make_device()
@@ -878,7 +830,6 @@ class TestLiveSensorInit:
             coordinator,
             device,
             "sys_fault_code",
-            "Fault Code",
             "sysFaultCode",
             entity_category=EntityCategory.DIAGNOSTIC,
         )
@@ -889,7 +840,7 @@ class TestLiveSensorInit:
         device = _make_device()
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.entity_category is None
 
@@ -897,7 +848,7 @@ class TestLiveSensorInit:
         device = _make_device()
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.entity_registry_enabled_default is True
 
@@ -909,7 +860,6 @@ class TestLiveSensorInit:
             coordinator,
             device,
             "sys_grid_energy_delta",
-            "System Grid Energy Delta",
             "sysGridEnergyDelta",
             enabled_default=False,
         )
@@ -923,28 +873,28 @@ class TestLiveSensorAvailable:
     def test_available_when_data_key_present(self):
         device = _make_device(last_status={"sysGridPower": 1.2}, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.available is True
 
     def test_unavailable_when_data_key_missing(self):
         device = _make_device(last_status={"other": True}, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.available is False
 
     def test_unavailable_when_no_status(self):
         device = _make_device(last_status=None, status_available=True)
         coordinator = _make_coordinator([device], last_update_success=True)
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.available is False
 
     def test_unavailable_when_device_not_found(self):
         device = _make_device(device_id="device_1")
         coordinator = _make_coordinator([], last_update_success=True)
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.available is False
 
@@ -955,21 +905,21 @@ class TestLiveSensorNativeValue:
     def test_returns_value_from_last_status(self):
         device = _make_device(last_status={"sysGridPower": 1.5})
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.native_value == 1.5
 
     def test_returns_none_when_data_key_missing(self):
         device = _make_device(last_status={"other": True})
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.native_value is None
 
     def test_returns_none_when_no_status(self):
         device = _make_device(last_status=None)
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         assert sensor.native_value is None
 
@@ -977,7 +927,7 @@ class TestLiveSensorNativeValue:
         device = _make_device(last_status={"lastSeen": "2024-02-19T10:30:00Z"})
         coordinator = _make_coordinator([device])
         sensor = AndersenEvLiveSensor(
-            coordinator, device, "last_seen", "Last Seen", "lastSeen", device_class=SensorDeviceClass.TIMESTAMP
+            coordinator, device, "last_seen", "lastSeen", device_class=SensorDeviceClass.TIMESTAMP
         )
 
         value = sensor.native_value
@@ -988,7 +938,7 @@ class TestLiveSensorNativeValue:
         device = _make_device(last_status={"lastSeen": "definitely-not-a-timestamp!!"})
         coordinator = _make_coordinator([device])
         sensor = AndersenEvLiveSensor(
-            coordinator, device, "last_seen", "Last Seen", "lastSeen", device_class=SensorDeviceClass.TIMESTAMP
+            coordinator, device, "last_seen", "lastSeen", device_class=SensorDeviceClass.TIMESTAMP
         )
 
         assert sensor.native_value is None
@@ -997,9 +947,7 @@ class TestLiveSensorNativeValue:
         original_device = _make_device(device_id="device_1", last_status=None)
         updated_device = _make_device(device_id="device_1", last_status={"sysGridPower": 3.3})
         coordinator = _make_coordinator([updated_device])
-        sensor = AndersenEvLiveSensor(
-            coordinator, original_device, "sys_grid_power", "System Grid Power", "sysGridPower"
-        )
+        sensor = AndersenEvLiveSensor(coordinator, original_device, "sys_grid_power", "sysGridPower")
 
         assert sensor.native_value == 3.3
         assert sensor._device is updated_device
@@ -1012,7 +960,7 @@ class TestLiveSensorAsyncUpdate:
     async def test_refreshes_from_api(self):
         device = _make_device()
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         await sensor.async_update()
 
@@ -1023,7 +971,7 @@ class TestLiveSensorAsyncUpdate:
         device = _make_device()
         device.get_detailed_device_status = AsyncMock(side_effect=RuntimeError("boom"))
         coordinator = _make_coordinator([device])
-        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "System Grid Power", "sysGridPower")
+        sensor = AndersenEvLiveSensor(coordinator, device, "sys_grid_power", "sysGridPower")
 
         await sensor.async_update()
 
@@ -1080,7 +1028,7 @@ class TestEnergySensorUnitConstants:
         device = _make_device()
         coordinator = _make_coordinator([device])
 
-        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "Total Energy", "chargeEnergyTotal")
+        sensor = AndersenEvEnergySensor(coordinator, device, "energy", "chargeEnergyTotal")
 
         assert sensor._attr_native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
         assert sensor._attr_device_class == SensorDeviceClass.ENERGY

--- a/custom_components/andersen_ev/tests/test_switch.py
+++ b/custom_components/andersen_ev/tests/test_switch.py
@@ -261,15 +261,15 @@ class TestDynamicDevices:
 class TestInit:
     """Tests for AndersenEvScheduleSwitch.__init__()."""
 
-    def test_sets_unique_id_name_icon_and_device_info(self):
+    def test_sets_unique_id_translation_key_and_device_info(self):
         device = _make_device(device_id="device_1", friendly_name="My Charger")
         coordinator = _make_coordinator([device])
 
         switch = _make_switch(coordinator, device, index=2, schedule_name="Weekend")
 
         assert switch._attr_unique_id == "device_1_schedule_2"
-        assert switch._attr_name == "Schedule 3"
-        assert switch._attr_icon == "mdi:calendar-clock"
+        assert switch._attr_translation_key == "schedule"
+        assert switch._attr_translation_placeholders == {"index": "3"}
         assert switch._attr_device_info["name"] == "My Charger (device_1)"
         assert switch._attr_has_entity_name is True
 

--- a/custom_components/andersen_ev/translations/en.json
+++ b/custom_components/andersen_ev/translations/en.json
@@ -8,6 +8,13 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Andersen EV",
+        "description": "The credentials for {email} are no longer valid. Please re-enter your password.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -16,7 +23,51 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Re-authentication successful"
     }
+  },
+  "entity": {
+    "sensor": {
+      "energy": { "name": "Total Energy" },
+      "grid_energy": { "name": "Grid Energy" },
+      "solar_energy": { "name": "Solar Energy" },
+      "surplus_energy": { "name": "Surplus Energy" },
+      "sys_grid_power": { "name": "System Grid Power" },
+      "sys_temperature": { "name": "System Temperature" },
+      "sys_voltage": { "name": "System Voltage" },
+      "sys_fault_code": { "name": "Fault Code" },
+      "sys_grid_energy_delta": { "name": "System Grid Energy Delta" },
+      "cost": { "name": "Total Cost" },
+      "grid_cost": { "name": "Grid Cost" },
+      "solar_cost": { "name": "Solar Cost" },
+      "surplus_cost": { "name": "Surplus Cost" },
+      "connector": { "name": "Connector" },
+      "charge_power": { "name": "Charge Power" },
+      "charge_power_max": { "name": "Max Charge Power" },
+      "solar_power": { "name": "Solar Power" },
+      "grid_power": { "name": "Grid Power" },
+      "current_charge_energy": { "name": "Current Session Energy" },
+      "current_solar_energy": { "name": "Current Session Solar Energy" },
+      "current_grid_energy": { "name": "Current Session Grid Energy" },
+      "session_start": { "name": "Session Start Time" }
+    },
+    "switch": {
+      "schedule": { "name": "Schedule {index}" }
+    },
+    "lock": {
+      "lock": { "name": "Lock" }
+    }
+  },
+  "exceptions": {
+    "device_not_found": { "message": "Device {device_id} not found" },
+    "get_device_info_failed": { "message": "Failed to retrieve device information for {device_id}" },
+    "get_device_status_failed": { "message": "Failed to retrieve device status for {device_id}" },
+    "lock_failed": { "message": "Failed to lock the charger {device_name}" },
+    "unlock_failed": { "message": "Failed to unlock the charger {device_name}" },
+    "schedule_data_unavailable": { "message": "Failed to retrieve schedule data for {device_name}" },
+    "schedule_update_failed": { "message": "Failed to update schedule for {device_name}" },
+    "schedule_index_out_of_range": { "message": "Schedule index {index} is out of range for {device_name}" },
+    "schedule_update_error": { "message": "Failed to update schedule for {device_name}: {error}" }
   }
 }


### PR DESCRIPTION
## What

Adds translation support for entity names, icons, and error messages (Home Assistant Quality Scale Gold rules: `entity-translations`, `icon-translations`, `exception-translations`).

- Sensor, switch, and lock entities now set `_attr_translation_key` (and `_attr_translation_placeholders` where a name has a variable part, like `Schedule {index}`) instead of hardcoded English names.
- Entity icons move from hardcoded Python to a new `icons.json` file.
- Raised `HomeAssistantError`s now carry a `translation_key` and `translation_placeholders` instead of a raw f-string message, so error text can be translated too.
- Fixed a pre-existing drift where `translations/en.json` was missing the `reauth_confirm`/`reauth_successful` strings that `strings.json` already had.

## Why it's safe

- No `_attr_unique_id` values changed, so no existing user entities are renamed or orphaned in the entity registry.
- Purely a presentation-layer change: entity behavior, state, and IDs are unchanged.

## Testing

- Full suite: 326 tests passing, 99.66% coverage (`./run-tests.sh`).
- Reviewed the diff manually against the HA translation conventions, then had an independent agent do a second, blind adversarial pass (no design context, diff only) looking for stateful/lifecycle bugs, key/placeholder mismatches, and unique_id stability. No defects found.
