### PR TITLE
feat: allow reconfiguring the integration without removing it

### DIFF
--- a/custom_components/andersen_ev/config_flow.py
+++ b/custom_components/andersen_ev/config_flow.py
@@ -115,6 +115,39 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=a
             errors=errors,
         )
 
+    async def async_step_reconfigure(self, user_input=None) -> FlowResult:
+        """Handle reconfiguration - update the password without removing the integration."""
+        errors = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            try:
+                await validate_input(
+                    self.hass,
+                    {
+                        CONF_EMAIL: reconfigure_entry.data[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during reconfigure")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={CONF_PASSWORD: user_input[CONF_PASSWORD]},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={"email": reconfigure_entry.data[CONF_EMAIL]},
+            errors=errors,
+        )
+
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -60,7 +60,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices: done
 

--- a/custom_components/andersen_ev/strings.json
+++ b/custom_components/andersen_ev/strings.json
@@ -15,6 +15,13 @@
         "data": {
           "password": "Password"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Andersen EV",
+        "description": "Update the password for {email}.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -24,7 +31,8 @@
     },
     "abort": {
       "already_configured": "This account is already configured",
-      "reauth_successful": "Re-authentication successful"
+      "reauth_successful": "Re-authentication successful",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "entity": {

--- a/custom_components/andersen_ev/tests/test_config_flow.py
+++ b/custom_components/andersen_ev/tests/test_config_flow.py
@@ -268,6 +268,88 @@ class TestAsyncStepReauth:
         flow.async_update_reload_and_abort.assert_not_called()
 
 
+def _make_reconfigure_flow(email="test@example.com", password="oldpass"):
+    """Create a ConfigFlow instance stubbed for reconfigure-step tests.
+
+    Builds on `_make_flow()` and additionally stubs `_get_reconfigure_entry` (normally supplied by
+    HA's flow manager for reconfigure flows) and `async_update_reload_and_abort`.
+    """
+    flow = _make_flow()
+    mock_entry = MagicMock()
+    mock_entry.data = {CONF_EMAIL: email, CONF_PASSWORD: password}
+    flow._get_reconfigure_entry = MagicMock(return_value=mock_entry)
+    flow.async_update_reload_and_abort = MagicMock(
+        side_effect=lambda entry, **kw: {"type": FlowResultType.ABORT, "reason": "reconfigure_successful"}
+    )
+    return flow
+
+
+class TestAsyncStepReconfigure:
+    """Tests for ConfigFlow.async_step_reconfigure()."""
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_no_input_shows_form_with_email(self):
+        """Calling reconfigure with no input shows the form with the stored email."""
+        flow = _make_reconfigure_flow(email="user@example.com")
+
+        result = await flow.async_step_reconfigure(None)
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+        assert result["description_placeholders"] == {"email": "user@example.com"}
+        assert result["errors"] == {}
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_success_updates_entry(self):
+        """A successful reconfigure updates the entry password and aborts with reconfigure_successful."""
+        flow = _make_reconfigure_flow(email="test@example.com", password="oldpass")
+
+        with _patch_konnect_client():
+            result = await flow.async_step_reconfigure({CONF_PASSWORD: "newpass"})
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        flow.async_update_reload_and_abort.assert_called_once()
+        _, kwargs = flow.async_update_reload_and_abort.call_args
+        assert kwargs["data_updates"] == {CONF_PASSWORD: "newpass"}
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_invalid_auth_shows_error(self):
+        """An AndersenAuthError during reconfigure re-shows the form with invalid_auth."""
+        flow = _make_reconfigure_flow()
+
+        with _patch_konnect_client(auth_error=AndersenAuthError("bad password")):
+            result = await flow.async_step_reconfigure({CONF_PASSWORD: "wrong"})
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "invalid_auth"}
+        flow.async_update_reload_and_abort.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_cannot_connect_shows_error(self):
+        """An AndersenConnectionError during reconfigure re-shows the form with cannot_connect."""
+        flow = _make_reconfigure_flow()
+
+        with _patch_konnect_client(auth_error=AndersenConnectionError("network down")):
+            result = await flow.async_step_reconfigure({CONF_PASSWORD: "newpass"})
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+        flow.async_update_reload_and_abort.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_unknown_error_shows_error(self):
+        """An unexpected exception during reconfigure re-shows the form with unknown."""
+        flow = _make_reconfigure_flow()
+
+        with patch("andersen_ev.config_flow.validate_input", AsyncMock(side_effect=Exception("boom"))):
+            result = await flow.async_step_reconfigure({CONF_PASSWORD: "newpass"})
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "unknown"}
+        flow.async_update_reload_and_abort.assert_not_called()
+
+
 class TestManifest:
     """Tests for the manifest.json declarations this feature relies on."""
 

--- a/custom_components/andersen_ev/translations/en.json
+++ b/custom_components/andersen_ev/translations/en.json
@@ -15,6 +15,13 @@
         "data": {
           "password": "Password"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Andersen EV",
+        "description": "Update the password for {email}.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -24,7 +31,8 @@
     },
     "abort": {
       "already_configured": "This account is already configured",
-      "reauth_successful": "Re-authentication successful"
+      "reauth_successful": "Re-authentication successful",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "entity": {


### PR DESCRIPTION
## What

Adds a reconfigure flow (`async_step_reconfigure`), the Home Assistant Quality Scale Gold rule `reconfiguration-flow`. Users can now update their Andersen account password from Settings > Devices & Services > the integration > Reconfigure, instead of removing and re-adding the integration.

## Design decision

This is scoped **password-only**: the email/account is fixed to whatever the existing config entry already has and is not user-editable in this flow. Reconfigure does not call `async_set_unique_id`, so it cannot repoint an existing entry at a different Andersen account.

Why: the config entry's `unique_id` is the account email. Letting reconfigure change the email would mean the entry could switch accounts entirely, which would prune the old account's devices and add a new account's devices (a real behavior change most users would not expect from what looks like "update my password"). Password-only avoids that entirely and matches the existing reauth flow's assumption (same account, just new credentials).

## Why it's safe

- No `unique_id` logic touched anywhere in this diff.
- Implementation mirrors the existing, already-shipped `async_step_reauth_confirm` flow line for line, just triggered by the user instead of by an auth failure.
- Purely additive: a new config-flow step and two new translation strings. No existing entity, device, or config-entry data changes.

## Testing

- Full suite: 331 tests passing (up from 326), coverage 99.67%, `config_flow.py` itself at 100%.
- Reviewed the diff manually against the reauth flow it mirrors, then had an independent agent do a second, blind adversarial pass (no design context, diff only) that additionally cross-checked the implementation against Home Assistant's actual installed `config_entries.py` source. No defects found.
