### PR TITLE
feat: surface a repair notification if Andersen's API changes unexpectedly

### DIFF
--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -22,7 +23,7 @@ from .const import (
     SERVICE_RCM_RESET,
 )
 from .konnect.client import KonnectClient
-from .konnect.exceptions import AndersenAuthError, AndersenError
+from .konnect.exceptions import AndersenApiError, AndersenAuthError, AndersenError
 
 PLATFORMS = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
 
@@ -215,11 +216,26 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
             devices = await self.client.getDevices()
         except AndersenAuthError as err:
             raise ConfigEntryAuthFailed("Authentication failed - please re-enter credentials") from err
+        except AndersenApiError as err:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                "api_shape_changed",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="api_shape_changed",
+            )
+            if self.devices:
+                _LOGGER.warning("API error, using cached device data: %s", err)
+                return self.devices
+            raise UpdateFailed(f"Error communicating with Andersen EV API: {err}") from err
         except AndersenError as err:
             if self.devices:
                 _LOGGER.warning("API error, using cached device data: %s", err)
                 return self.devices
             raise UpdateFailed(f"Error communicating with Andersen EV API: {err}") from err
+
+        ir.async_delete_issue(self.hass, DOMAIN, "api_shape_changed")
 
         if not devices:
             if self.devices:

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -9,7 +9,7 @@ from pycognito.aws_srp import AWSSRP
 
 from . import const
 from .device import KonnectDevice
-from .exceptions import AndersenAuthError, AndersenConnectionError
+from .exceptions import AndersenApiError, AndersenAuthError, AndersenConnectionError
 
 POOL_ID = "eu-west-1_t5HV3bFjl"
 POOL_REGION = "eu-west-1"
@@ -200,7 +200,10 @@ class KonnectClient:
 
         response_body = response.json()
 
-        if not response_body.get("devices"):
+        if "devices" not in response_body:
+            raise AndersenApiError("Unexpected API response shape: missing 'devices' key")
+
+        if not response_body["devices"]:
             _LOGGER.warning("No devices found in API response")
             return devices
 

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -61,7 +61,7 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
-  repair-issues: todo
+  repair-issues: done
   stale-devices: done
 
   # Platinum

--- a/custom_components/andersen_ev/strings.json
+++ b/custom_components/andersen_ev/strings.json
@@ -77,5 +77,11 @@
     "schedule_update_failed": { "message": "Failed to update schedule for {device_name}" },
     "schedule_index_out_of_range": { "message": "Schedule index {index} is out of range for {device_name}" },
     "schedule_update_error": { "message": "Failed to update schedule for {device_name}: {error}" }
+  },
+  "issues": {
+    "api_shape_changed": {
+      "title": "Andersen API response format has changed",
+      "description": "The Andersen EV cloud API returned data in an unexpected format. This usually means Andersen changed their API and the integration may need to be updated. Please check for an integration update, or report this issue if none is available."
+    }
   }
 }

--- a/custom_components/andersen_ev/tests/test_client.py
+++ b/custom_components/andersen_ev/tests/test_client.py
@@ -8,7 +8,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from andersen_ev.konnect.client import KonnectClient
-from andersen_ev.konnect.exceptions import AndersenAuthError, AndersenConnectionError
+from andersen_ev.konnect.exceptions import AndersenApiError, AndersenAuthError, AndersenConnectionError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -426,6 +426,22 @@ class TestGetDevices:
             devices = await client.getDevices()
 
         assert devices == []
+
+    @pytest.mark.asyncio
+    async def test_get_devices_missing_devices_key_raises_api_error(self):
+        """getDevices() raises AndersenApiError when the response body has no 'devices' key at all."""
+        client = KonnectClient("user@example.com", "password")
+        client.ensure_valid_auth = AsyncMock()
+        client.token = "abc"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"unexpected": "shape"}
+
+        with patch("andersen_ev.konnect.client.requests") as mock_requests:
+            mock_requests.get.return_value = mock_response
+            with pytest.raises(AndersenApiError):
+                await client.getDevices()
 
     @pytest.mark.asyncio
     async def test_get_devices_retries_after_401(self):

--- a/custom_components/andersen_ev/tests/test_init.py
+++ b/custom_components/andersen_ev/tests/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.const import Platform
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from andersen_ev import (
@@ -22,15 +23,16 @@ from andersen_ev.const import (
     SERVICE_GET_DEVICE_STATUS,
     SERVICE_RCM_RESET,
 )
-from andersen_ev.konnect.exceptions import AndersenAuthError, AndersenError
+from andersen_ev.konnect.exceptions import AndersenApiError, AndersenAuthError, AndersenError
 
 
-def _make_coordinator(client=None):
+def _make_coordinator(client=None, hass=None):
     """Build an AndersenEvCoordinator without running DataUpdateCoordinator.__init__."""
     coordinator = AndersenEvCoordinator.__new__(AndersenEvCoordinator)
     coordinator.client = client or MagicMock()
     coordinator.devices = []
     coordinator._device_availability = {}
+    coordinator.hass = hass if hass is not None else MagicMock()
     return coordinator
 
 
@@ -105,6 +107,18 @@ class TestAsyncUpdateData:
         assert coordinator._device_availability[device.device_id] is True
 
     @pytest.mark.asyncio
+    async def test_successful_update_clears_api_shape_repair_issue(self):
+        device = _make_device()
+        client = MagicMock()
+        client.getDevices = AsyncMock(return_value=[device])
+        coordinator = _make_coordinator(client)
+
+        with patch("andersen_ev.ir.async_delete_issue") as mock_delete_issue:
+            await coordinator._async_update_data()
+
+        mock_delete_issue.assert_called_once_with(coordinator.hass, DOMAIN, "api_shape_changed")
+
+    @pytest.mark.asyncio
     async def test_auth_error_raises_config_entry_auth_failed(self):
         client = MagicMock()
         client.getDevices = AsyncMock(side_effect=AndersenAuthError("bad credentials"))
@@ -133,6 +147,41 @@ class TestAsyncUpdateData:
 
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_api_shape_error_creates_repair_issue_and_raises_update_failed(self):
+        client = MagicMock()
+        client.getDevices = AsyncMock(side_effect=AndersenApiError("missing 'devices' key"))
+        coordinator = _make_coordinator(client)
+
+        with (
+            patch("andersen_ev.ir.async_create_issue") as mock_create_issue,
+            pytest.raises(UpdateFailed),
+        ):
+            await coordinator._async_update_data()
+
+        mock_create_issue.assert_called_once()
+        args, kwargs = mock_create_issue.call_args
+        assert args[0] is coordinator.hass
+        assert args[1] == DOMAIN
+        assert args[2] == "api_shape_changed"
+        assert kwargs["translation_key"] == "api_shape_changed"
+        assert kwargs["is_fixable"] is False
+        assert kwargs["severity"] == ir.IssueSeverity.ERROR
+
+    @pytest.mark.asyncio
+    async def test_api_shape_error_with_cache_creates_issue_and_returns_cached_devices(self):
+        cached_device = _make_device()
+        client = MagicMock()
+        client.getDevices = AsyncMock(side_effect=AndersenApiError("missing 'devices' key"))
+        coordinator = _make_coordinator(client)
+        coordinator.devices = [cached_device]
+
+        with patch("andersen_ev.ir.async_create_issue") as mock_create_issue:
+            result = await coordinator._async_update_data()
+
+        assert result == [cached_device]
+        mock_create_issue.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_empty_devices_with_cache_returns_cached_devices(self):

--- a/custom_components/andersen_ev/translations/en.json
+++ b/custom_components/andersen_ev/translations/en.json
@@ -77,5 +77,11 @@
     "schedule_update_failed": { "message": "Failed to update schedule for {device_name}" },
     "schedule_index_out_of_range": { "message": "Schedule index {index} is out of range for {device_name}" },
     "schedule_update_error": { "message": "Failed to update schedule for {device_name}: {error}" }
+  },
+  "issues": {
+    "api_shape_changed": {
+      "title": "Andersen API response format has changed",
+      "description": "The Andersen EV cloud API returned data in an unexpected format. This usually means Andersen changed their API and the integration may need to be updated. Please check for an integration update, or report this issue if none is available."
+    }
   }
 }


### PR DESCRIPTION
## What

Implements roadmap item G6 (Gold tier): the `repair-issues` Home Assistant quality-scale rule.

Today, if Andersen changes the shape of the `getDevices` API response (e.g. renames or drops the
`devices` key), the integration silently treats it the same as "this account has no chargers" -
no error, just an empty device list. That's misleading: it looks like normal state, not a break.

## How

- `KonnectClient.getDevices()` now distinguishes a **missing** `devices` key (API shape genuinely
  changed) from a **present but empty** `devices` list (a normal empty account) - only the former
  raises a new, specific `AndersenApiError`.
- The coordinator catches `AndersenApiError` and creates a persistent Home Assistant repair issue
  (Settings > Repairs) telling the user Andersen's API response format has changed and to check for
  an integration update. It still falls back to cached device data (or raises `UpdateFailed` if none
  exists) exactly as before - this only adds the visible notification, it doesn't change update
  behavior.
- The repair issue clears itself automatically the next time an update succeeds.

Out of scope (deliberately, per the roadmap): the broader API-resilience/async rewrite tracked
separately as a future item. This PR only adds the repair-issue surface for the one concrete,
detectable shape-break case.

## Testing

- `./run-tests.sh` - full suite green, 99.67% coverage (gate is 95%)
- New tests cover: missing vs. empty `devices` key in `getDevices()`, repair issue created on a
  shape error (both with and without cached data), and repair issue cleared on the next successful
  update
- Reviewed independently (design review + a second, blind adversarial pass against the diff alone)

`quality_scale.yaml`: `repair-issues` marked `done`.
