### PR TITLE
chore: claim Gold quality scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Status
 ![CI](https://github.com/HA-AndersenEV/hassio-andersen-ev/actions/workflows/ci.yml/badge.svg?branch=main)
-![HA Quality Scale: Silver](https://img.shields.io/badge/HA_Quality_Scale-Silver-c0c0c0)
+![HA Quality Scale: Gold](https://img.shields.io/badge/HA_Quality_Scale-Gold-FFD700)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/HA-AndersenEV/hassio-andersen-ev)](https://github.com/HA-AndersenEV/hassio-andersen-ev/releases)
 ![Integration Usage](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.andersen_ev.total)

--- a/custom_components/andersen_ev/manifest.json
+++ b/custom_components/andersen_ev/manifest.json
@@ -12,7 +12,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/HA-AndersenEV/hassio-andersen-ev/issues",
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": [
     "pycognito",
     "gql[aiohttp]",

--- a/custom_components/andersen_ev/quality_scale.yaml
+++ b/custom_components/andersen_ev/quality_scale.yaml
@@ -38,7 +38,7 @@ rules:
   test-coverage: done
 
   # Gold
-  devices: todo
+  devices: done
   diagnostics: done
   discovery:
     status: exempt


### PR DESCRIPTION
## Summary

Closes out the Gold Gate: the last remaining Gold tier item.

- `quality_scale.yaml`: flip `devices` from `todo` to `done`. This rule was already satisfied by earlier work (standardized `_attr_device_info` across all entities, dynamic/stale device handling from #78) but never got flipped in the yaml when that PR merged.
- `manifest.json`: `quality_scale` `silver` to `gold`.
- `README.md`: quality scale badge updated to Gold.

No CI changes needed: hassfest validation and the 95% coverage floor are already hard gates from Bronze and Silver. This PR is a documentation/metadata only change, no production code touched.

## Verification

- Confirmed every entity class (sensor, switch, lock) sets `_attr_device_info` via the shared mixin, keyed consistently by `device.device_id`, with stale device cleanup in the coordinator.
- Confirmed every other Gold tier rule in `quality_scale.yaml` is already `done` or `status: exempt` (discovery and discovery-update-info are exempt as a cloud only integration). `devices` was the only gap.
- Ran the full local test suite: 335 passed, 99.67% coverage (floor is 95%).
- Independent blind adversarial review of the diff found no defects.
