### PR TITLE
fix: clean up type checking errors and enforce the Typecheck CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up uv
@@ -89,13 +88,13 @@ jobs:
     # Stable required-status-check target: its name never changes when the
     # test matrix changes, so branch protection can require this one context.
     if: ${{ always() }}
-    needs: [lint, test, hassfest, hacs]
+    needs: [lint, test, hassfest, hacs, typecheck]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs succeeded
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.hassfest.result }}" != "success" ] || [ "${{ needs.hacs.result }}" != "success" ]; then
-            echo "A required job did not succeed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, hassfest=${{ needs.hassfest.result }}, hacs=${{ needs.hacs.result }})"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.hassfest.result }}" != "success" ] || [ "${{ needs.hacs.result }}" != "success" ] || [ "${{ needs.typecheck.result }}" != "success" ]; then
+            echo "A required job did not succeed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }}, hassfest=${{ needs.hassfest.result }}, hacs=${{ needs.hacs.result }}, typecheck=${{ needs.typecheck.result }})"
             exit 1
           fi
           echo "All required jobs succeeded"

--- a/custom_components/andersen_ev/__init__.py
+++ b/custom_components/andersen_ev/__init__.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
@@ -23,6 +23,7 @@ from .const import (
     SERVICE_RCM_RESET,
 )
 from .konnect.client import KonnectClient
+from .konnect.device import KonnectDevice
 from .konnect.exceptions import AndersenApiError, AndersenAuthError, AndersenError
 
 PLATFORMS = [Platform.LOCK, Platform.SENSOR, Platform.SWITCH]
@@ -84,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="device_not_found",
-                translation_placeholders={"device_id": device_id},
+                translation_placeholders={"device_id": str(device_id)},
             )
 
     async def get_device_info(call: ServiceCall) -> dict:
@@ -101,13 +102,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="get_device_info_failed",
-                    translation_placeholders={"device_id": device_id},
+                    translation_placeholders={"device_id": str(device_id)},
                 )
 
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="device_not_found",
-            translation_placeholders={"device_id": device_id},
+            translation_placeholders={"device_id": str(device_id)},
         )
 
     async def get_device_status(call: ServiceCall) -> dict:
@@ -123,13 +124,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="get_device_status_failed",
-                    translation_placeholders={"device_id": device_id},
+                    translation_placeholders={"device_id": str(device_id)},
                 )
 
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="device_not_found",
-            translation_placeholders={"device_id": device_id},
+            translation_placeholders={"device_id": str(device_id)},
         )
 
     async def reset_rcm(call: ServiceCall) -> None:
@@ -146,7 +147,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="device_not_found",
-                translation_placeholders={"device_id": device_id},
+                translation_placeholders={"device_id": str(device_id)},
             )
 
     # Register services using simpler schema
@@ -160,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
         SERVICE_GET_DEVICE_INFO,
         get_device_info,
         schema=service_schema,
-        supports_response=True,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     # Register the get_device_status service with response support
@@ -169,7 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) -
         SERVICE_GET_DEVICE_STATUS,
         get_device_status,
         schema=service_schema,
-        supports_response=True,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     # Register the reset_rcm service
@@ -185,7 +186,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: AndersenEvConfigEntry) 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-class AndersenEvCoordinator(DataUpdateCoordinator):
+class AndersenEvCoordinator(DataUpdateCoordinator[list[KonnectDevice]]):
     """Data update coordinator for Andersen EV."""
 
     def __init__(self, hass: HomeAssistant, entry: AndersenEvConfigEntry, client: KonnectClient) -> None:
@@ -198,7 +199,7 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
         self.client = client
-        self.devices = []
+        self.devices: list[KonnectDevice] = []
         self._device_availability: dict[str, bool] = {}
 
     async def async_request_refresh(self) -> None:
@@ -210,7 +211,7 @@ class AndersenEvCoordinator(DataUpdateCoordinator):
         await asyncio.sleep(1.5)
         await super().async_request_refresh()
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> list[KonnectDevice]:
         """Fetch data from API endpoint."""
         try:
             devices = await self.client.getDevices()

--- a/custom_components/andersen_ev/config_flow.py
+++ b/custom_components/andersen_ev/config_flow.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN
@@ -58,7 +58,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=a
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None) -> FlowResult:
+    async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:
@@ -78,11 +78,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=a
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
 
-    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> ConfigFlowResult:
         """Handle reauth when credentials become invalid."""
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+    async def async_step_reauth_confirm(self, user_input=None) -> ConfigFlowResult:
         """Handle reauth confirmation step - user re-enters password."""
         errors = {}
         reauth_entry = self._get_reauth_entry()
@@ -115,7 +115,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pylint: disable=a
             errors=errors,
         )
 
-    async def async_step_reconfigure(self, user_input=None) -> FlowResult:
+    async def async_step_reconfigure(self, user_input=None) -> ConfigFlowResult:
         """Handle reconfiguration - update the password without removing the integration."""
         errors = {}
         reconfigure_entry = self._get_reconfigure_entry()

--- a/custom_components/andersen_ev/entity.py
+++ b/custom_components/andersen_ev/entity.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from homeassistant.helpers.entity import DeviceInfo
+
+from .konnect.device import KonnectDevice
+
 
 class AndersenEvDeviceInfoMixin:
     """Mixin providing shared device-info update logic for Andersen EV entities.
@@ -11,8 +15,12 @@ class AndersenEvDeviceInfoMixin:
     ``_update_model_from_device_status``.
     """
 
+    _device: KonnectDevice
+    _attr_device_info: DeviceInfo | None
+
     def _update_model_from_device_status(self) -> None:
         """Update model information from device status if available."""
+        assert self._attr_device_info is not None, "_attr_device_info must be set before this call"
         # First try to use the model name from the API if available
         if hasattr(self._device, "model_name") and self._device.model_name:
             self._attr_device_info["model"] = self._device.model_name

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import time
@@ -19,16 +21,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class KonnectClient:
-    email = None
-    username = None
-    password = None
+    email: str
+    username: str | None = None
+    password: str
 
-    token = None
-    tokenType = None
-    tokenExpiresIn = None
-    tokenExpiryTime = None  # New field to track token expiration time
-    refreshToken = None
-    deviceKey = None
+    token: str | None = None
+    tokenType: str | None = None
+    tokenExpiresIn: int | None = None
+    tokenExpiryTime: float | None = None  # New field to track token expiration time
+    refreshToken: str | None = None
+    deviceKey: str | None = None
 
     def __init__(self, email, password):
         self.email = email

--- a/custom_components/andersen_ev/konnect/device.py
+++ b/custom_components/andersen_ev/konnect/device.py
@@ -1,9 +1,15 @@
 """Konnect device interface for Andersen EV chargers."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Any
 
 from . import const
 from .graphql_client import GraphQLClient
+
+if TYPE_CHECKING:
+    from .client import KonnectClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,13 +17,13 @@ _LOGGER = logging.getLogger(__name__)
 class KonnectDevice:
     """Represents an Andersen EV charger and its GraphQL operations."""
 
-    api = None
-    device_id = None
-    friendly_name = None
-    user_lock = False
-    _last_status = None
-    model_name = None
-    _graphql_client = None  # GraphQL client instance
+    api: KonnectClient
+    device_id: str
+    friendly_name: str
+    user_lock: bool = False
+    _last_status: dict[str, Any] | None = None
+    model_name: str | None = None
+    _graphql_client: GraphQLClient | None = None  # GraphQL client instance
 
     def __init__(self, api, device_id, friendly_name, user_lock):
         """Initialize the device."""
@@ -39,6 +45,7 @@ class KonnectDevice:
     def graphql_client(self) -> GraphQLClient:
         """Lazily create the GraphQL client on first use."""
         if self._graphql_client is None:
+            assert self.api.token is not None, "graphql_client accessed before authentication"
             self._graphql_client = GraphQLClient(
                 token=self.api.token,
                 token_refresh=self._refresh_graphql_token,

--- a/custom_components/andersen_ev/konnect/graphql_client.py
+++ b/custom_components/andersen_ev/konnect/graphql_client.py
@@ -8,14 +8,15 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from gql import Client, gql
+from gql import Client, GraphQLRequest, gql
+from gql.client import AsyncClientSession
 from gql.dsl import DSLMutation, DSLSchema, dsl_gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import (
     TransportQueryError,
     TransportServerError,
 )
-from graphql import DocumentNode, build_schema
+from graphql import build_schema
 
 from . import const
 
@@ -76,7 +77,7 @@ class GraphQLClient:
         self.url = url
         self._token_refresh = token_refresh
         self._client: Client | None = None
-        self._session = None
+        self._session: AsyncClientSession | None = None
         self._refresh_handle: asyncio.TimerHandle | None = None
         self._initial_expiry_time = token_expiry_time
         self._refresh_task: asyncio.Task[None] | None = None
@@ -152,24 +153,24 @@ class GraphQLClient:
     # -- execution ---------------------------------------------------------
 
     @staticmethod
-    def _parse_document(query: str) -> DocumentNode:
-        """Parse a GraphQL query string into a DocumentNode."""
+    def _parse_document(query: str) -> GraphQLRequest:
+        """Parse a GraphQL query string into a GraphQLRequest."""
         return gql(query)
 
     async def execute_document(
         self,
-        document: DocumentNode,
+        document: GraphQLRequest,
         *,
         variable_values: dict[str, Any] | None = None,
         operation_name: str = "",
     ) -> dict[str, Any] | None:
-        """Execute a pre-built GraphQL DocumentNode.
+        """Execute a pre-built GraphQL request.
 
         This is the core execution method. It handles 401 auth failures by
         refreshing the token and retrying once.
 
         Args:
-            document: A parsed GraphQL DocumentNode (from gql() or dsl_gql()).
+            document: A parsed GraphQL request (from gql() or dsl_gql()).
             variable_values: Optional variable values for parameterised queries.
             operation_name: Name of the operation in the document.  Sent to
                 the server and used in log messages.  Leave empty for
@@ -180,14 +181,12 @@ class GraphQLClient:
         """
         label = operation_name or "GraphQL operation"
         wire_op_name = operation_name or None
+        request = GraphQLRequest(document, variable_values=variable_values, operation_name=wire_op_name)
 
         try:
             await self._ensure_connected()
-            return await self._session.execute(
-                document,
-                variable_values=variable_values,
-                operation_name=wire_op_name,
-            )
+            assert self._session is not None
+            return await self._session.execute(request)
         except TransportServerError as err:
             if err.code != 401:
                 _LOGGER.warning("Failed %s, HTTP status code: %s", label, err.code)
@@ -274,19 +273,17 @@ class GraphQLClient:
 
     async def _refresh_and_retry(
         self,
-        document: DocumentNode,
+        document: GraphQLRequest,
         variable_values: dict[str, Any] | None,
         wire_op_name: str | None,
         label: str,
     ) -> dict[str, Any] | None:
         """Refresh the token and retry the operation once."""
+        request = GraphQLRequest(document, variable_values=variable_values, operation_name=wire_op_name)
         try:
             await self._refresh_and_reconnect()
-            return await self._session.execute(
-                document,
-                variable_values=variable_values,
-                operation_name=wire_op_name,
-            )
+            assert self._session is not None
+            return await self._session.execute(request)
         except (TransportServerError, TransportQueryError, OSError) as retry_err:
             _LOGGER.error(
                 "Retry after token refresh failed for %s: %s",

--- a/custom_components/andersen_ev/lock.py
+++ b/custom_components/andersen_ev/lock.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_handle_coordinator_update))
 
 
-class AndersenEvLock(AndersenEvDeviceInfoMixin, CoordinatorEntity, LockEntity):  # pylint: disable=abstract-method
+class AndersenEvLock(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], LockEntity):  # pylint: disable=abstract-method
     """Representation of an Andersen EV charging lock."""
 
     _attr_has_entity_name = True

--- a/custom_components/andersen_ev/sensor.py
+++ b/custom_components/andersen_ev/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar
 
 import dateutil.parser
 from homeassistant.components.sensor import (
@@ -289,7 +288,7 @@ def _build_entities_for_device(coordinator: AndersenEvCoordinator, device) -> li
     return entities
 
 
-class AndersenEvBaseSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorEntity):
+class AndersenEvBaseSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], SensorEntity):
     """Base class for Andersen EV sensors."""
 
     _attr_has_entity_name = True
@@ -380,11 +379,13 @@ class AndersenEvCostSensor(AndersenEvBaseSensor):
         return None
 
 
-class AndersenEvConnectorSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorEntity):
+class AndersenEvConnectorSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], SensorEntity):
     """Sensor for Andersen EV connector state."""
 
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options: ClassVar[list[str]] = [
+    # Not ClassVar: SensorEntity itself declares _attr_options as an instance
+    # variable, so a ClassVar override here would conflict with mypy's override check.
+    _attr_options: list[str] = [  # noqa: RUF012
         "Ready",
         "Connected",
         "Charging",
@@ -491,7 +492,7 @@ class AndersenEvConnectorSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, Se
             _LOGGER.debug("Error updating connector state: %s", err)
 
 
-class AndersenEvChargeStatusSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorEntity):
+class AndersenEvChargeStatusSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], SensorEntity):
     """Sensor for Andersen EV charge status values."""
 
     _attr_has_entity_name = True
@@ -581,7 +582,7 @@ class AndersenEvChargeStatusSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity,
             _LOGGER.debug("Error updating charge status sensor: %s", err)
 
 
-class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity, SensorEntity):
+class AndersenEvLiveSensor(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], SensorEntity):
     """Sensor for Andersen EV live status values."""
 
     _attr_has_entity_name = True

--- a/custom_components/andersen_ev/switch.py
+++ b/custom_components/andersen_ev/switch.py
@@ -99,7 +99,7 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_handle_coordinator_update))
 
 
-class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity, SwitchEntity):  # pylint: disable=abstract-method
+class AndersenEvScheduleSwitch(AndersenEvDeviceInfoMixin, CoordinatorEntity[AndersenEvCoordinator], SwitchEntity):  # pylint: disable=abstract-method
     """Representation of an Andersen EV charging schedule switch."""
 
     _attr_has_entity_name = True

--- a/custom_components/andersen_ev/tests/test_graphql_client.py
+++ b/custom_components/andersen_ev/tests/test_graphql_client.py
@@ -92,8 +92,8 @@ class TestGraphQLClient:
             await client.close()
 
         assert result is not None
-        call_kwargs = mock_session.execute.call_args[1]
-        assert call_kwargs.get("variable_values") is None
+        sent_request = mock_session.execute.call_args[0][0]
+        assert sent_request.variable_values is None
 
     # -- persistent session tests ------------------------------------------
 
@@ -630,8 +630,9 @@ class TestExecuteDocument:
             await client.close()
 
         assert result == data
-        call_kwargs = mock_session.execute.call_args[1]
-        assert call_kwargs["variable_values"] == {"id": "123"}
+        sent_request = mock_session.execute.call_args[0][0]
+        assert sent_request.variable_values == {"id": "123"}
+        assert sent_request.operation_name == "getDevice"
 
 
 class TestSolarOperations:

--- a/custom_components/andersen_ev/tests/test_init.py
+++ b/custom_components/andersen_ev/tests/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import Platform
+from homeassistant.core import SupportsResponse
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -452,8 +453,8 @@ class TestAsyncSetupEntry:
         }
         for registered_call in hass.services.async_register.call_args_list:
             assert registered_call.args[0] == DOMAIN
-        assert registered[SERVICE_GET_DEVICE_INFO].kwargs["supports_response"] is True
-        assert registered[SERVICE_GET_DEVICE_STATUS].kwargs["supports_response"] is True
+        assert registered[SERVICE_GET_DEVICE_INFO].kwargs["supports_response"] is SupportsResponse.OPTIONAL
+        assert registered[SERVICE_GET_DEVICE_STATUS].kwargs["supports_response"] is SupportsResponse.OPTIONAL
 
     @pytest.mark.asyncio
     async def test_forwards_platform_setup(self):


### PR DESCRIPTION
## What

Burns the Typecheck CI job's mypy baseline down to zero (was report only, with
a growing set of pre-existing errors) and turns it into a required, blocking
check.

## Why

The Typecheck job has been non-blocking since it was added, so it has quietly
accumulated errors without anyone needing to fix them. This is a separate,
smaller step than the full Platinum "strict typing" quality scale rule
(mypy --strict), which stays out of scope for now. It just gets the existing,
normal-mode mypy config to a clean, enforceable baseline.

## What changed

Most of the errors traced back to a few root causes rather than being one off
issues:

- `AndersenEvCoordinator` and the `CoordinatorEntity` subclasses (lock, sensor,
  switch platforms) were never generic parametrized, so mypy silently treated
  `coordinator.data` as the library default type instead of the real
  `list[KonnectDevice]`, which was hiding real typing gaps everywhere that data
  is used.
- `KonnectDevice` and `KonnectClient` attributes were untyped, so mypy could
  not tell they were ever anything other than `None`. Added real type
  annotations, plus one assertion documenting that the GraphQL client is never
  created before authentication has produced a token.
- `graphql_client.py` was calling the installed `gql` 4.0 library through its
  deprecated 3.x calling convention (loose `variable_values` / `operation_name`
  keyword arguments). Modernized it to build a `GraphQLRequest` explicitly,
  matching the library's current API. Confirmed this preserves behavior for
  every call site, including the DSL based solar mutation and the token
  refresh retry path.
- `config_flow.py` used the legacy, generic less `FlowResult` type instead of
  `ConfigFlowResult`, which is what `ConfigFlow` methods actually return.
- Replaced the deprecated bool `supports_response=True` with the current
  `SupportsResponse.OPTIONAL` enum value (same behavior).

Updated two tests whose assertions were written against the old `gql` calling
convention and the old bool `supports_response` value.

## Verification

- `mypy custom_components/andersen_ev`: clean, 0 errors (was 61)
- `ruff check` and `ruff format --check`: clean
- Full test suite: 335/335 passing, 99.67% coverage
- Independent adversarial review of the diff found no defects (traced every
  added assertion against the real call graph, and the gql calling convention
  change against the installed library source)

## CI

Dropped `continue-on-error: true` on the `typecheck` job and added it to the
`CI Success` required gate's `needs`.
